### PR TITLE
Use more bits to store pin number. Enables servo support on A10-A15 on Mega.

### DIFF
--- a/src/Servo.h
+++ b/src/Servo.h
@@ -88,7 +88,7 @@
 #if !defined(ARDUINO_ARCH_STM32F4)
 
 typedef struct  {
-  uint8_t nbr        :6 ;             // a pin number from 0 to 63
+  uint8_t nbr        :7 ;             // a pin number from 0 to 127
   uint8_t isActive   :1 ;             // true if this channel is enabled, pin not pulsed if false 
 } ServoPin_t   ;  
 


### PR DESCRIPTION
Servo.h currently uses 6 bits to store the pin number attached to a servo. On the Arduino Mega 2560 pins A10-A15 are mapped to 65-69.  If a user attempts to attach a Servo object to these pins the 7th bit is truncated. This results pins A10-A15 (65-69) to be silently remapped to pins 0-5. The Servo library will then attempt to pulse pins 0-5 instead of 65-69.

The proposed solution simply is to use 7 bits to store the pin number instead of 6.