### PR TITLE
Correct megaavr architecture name in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Allows Arduino/Genuino boards to control a variety of servo motors.
 paragraph=This library can control a great number of servos.<br />It makes careful use of timers: the library can control 12 servos using only 1 timer.<br />On the Arduino Due you can control up to 60 servos.<br />
 category=Device Control
 url=http://www.arduino.cc/en/Reference/Servo
-architectures=avr,megaAVR,sam,samd,nrf52,stm32f4
+architectures=avr,megaavr,sam,samd,nrf52,stm32f4


### PR DESCRIPTION
Previous incorrect case of the megaavr architecture name caused a warning on compilation:
```
WARNING: library Servo claims to run on (avr, megaAVR, sam, samd, nrf52, stm32f4) architecture(s) and may be incompatible with your current board which runs on (megaavr) architecture(s).
```

Originally reported at http://forum.arduino.cc/index.php?topic=580766