### PR TITLE
Constructor, attacch, detach change

### DIFF
--- a/src/Servo.h
+++ b/src/Servo.h
@@ -17,32 +17,32 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-/*
-  A servo is activated by creating an instance of the Servo class passing
+/* 
+  A servo is activated by creating an instance of the Servo class passing 
   the desired pin to the attach() method.
-  The servos are pulsed in the background using the value most recently
+  The servos are pulsed in the background using the value most recently 
   written using the write() method.
 
-  Note that analogWrite of PWM on pins associated with the timer are
+  Note that analogWrite of PWM on pins associated with the timer are 
   disabled when the first servo is attached.
-  Timers are seized as needed in groups of 12 servos - 24 servos use two
+  Timers are seized as needed in groups of 12 servos - 24 servos use two 
   timers, 48 servos will use four.
   The sequence used to sieze timers is defined in timers.h
 
   The methods are:
 
-	Servo - Class for manipulating servo motors connected to Arduino pins.
+    Servo - Class for manipulating servo motors connected to Arduino pins.
 
-	attach(pin )  - Attaches a servo motor to an i/o pin.
-	attach(pin, min, max  ) - Attaches to a pin setting min and max values in microseconds
-	default min is 544, max is 2400
-
-	write()     - Sets the servo angle in degrees.  (invalid angle that is valid as pulse in microseconds is treated as microseconds)
-	writeMicroseconds() - Sets the servo pulse width in microseconds
-	read()      - Gets the last written servo pulse width as an angle between 0 and 180.
-	readMicroseconds()   - Gets the last written servo pulse width in microseconds. (was read_us() in first release)
-	attached()  - Returns true if there is a servo attached.
-	detach()    - Stops an attached servos from pulsing its i/o pin.
+    attach(pin )  - Attaches a servo motor to an i/o pin.
+    attach(pin, min, max  ) - Attaches to a pin setting min and max values in microseconds
+    default min is 544, max is 2400  
+ 
+    write()     - Sets the servo angle in degrees.  (invalid angle that is valid as pulse in microseconds is treated as microseconds)
+    writeMicroseconds() - Sets the servo pulse width in microseconds 
+    read()      - Gets the last written servo pulse width as an angle between 0 and 180. 
+    readMicroseconds()   - Gets the last written servo pulse width in microseconds. (was read_us() in first release)
+    attached()  - Returns true if there is a servo attached. 
+    detach()    - Stops an attached servos from pulsing its i/o pin. 
  */
 
 #ifndef Servo_h
@@ -50,15 +50,15 @@
 
 #include <inttypes.h>
 
- /*
-  * Defines for 16 bit timers used with  Servo library
-  *
-  * If _useTimerX is defined then TimerX is a 16 bit timer on the current board
-  * timer16_Sequence_t enumerates the sequence that the timers should be allocated
-  * _Nbr_16timers indicates how many 16 bit timers are available.
-  */
+/* 
+ * Defines for 16 bit timers used with  Servo library 
+ *
+ * If _useTimerX is defined then TimerX is a 16 bit timer on the current board
+ * timer16_Sequence_t enumerates the sequence that the timers should be allocated
+ * _Nbr_16timers indicates how many 16 bit timers are available.
+ */
 
-  // Architecture specific include
+// Architecture specific include
 #if defined(ARDUINO_ARCH_AVR)
 #include "avr/ServoTimers.h"
 #elif defined(ARDUINO_ARCH_SAM)
@@ -89,39 +89,33 @@
 
 #if !defined(ARDUINO_ARCH_STM32F4)
 
-typedef struct {
-	uint8_t nbr : 6;             // a pin number from 0 to 63
-	uint8_t isActive : 1;             // true if this channel is enabled, pin not pulsed if false 
-} ServoPin_t;
+typedef struct  {
+  uint8_t nbr        :6 ;             // a pin number from 0 to 63
+  uint8_t isActive   :1 ;             // true if this channel is enabled, pin not pulsed if false 
+} ServoPin_t   ;  
 
 typedef struct {
-	ServoPin_t Pin;
-	volatile unsigned int ticks;
+  ServoPin_t Pin;
+  volatile unsigned int ticks;
 } servo_t;
-
-typedef struct {
-	volatile short int index[MAX_SERVOS];
-	volatile short int freePosition;
-	volatile short int actualPosition;
-} index_queue;
 
 class Servo
 {
 public:
-	Servo();
-	uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
-	uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes. 
-	void detach();
-	void write(int value);             // if value is < 200 its treated as an angle, otherwise as pulse width in microseconds 
-	void writeMicroseconds(int value); // Write pulse width in microseconds 
-	int read();                        // returns current pulse width as an angle between 0 and 180 degrees
-	int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
-	bool attached();                   // return true if this servo is attached, otherwise false 
+  Servo();
+  uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
+  uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes. 
+  void detach();
+  void write(int value);             // if value is < 200 its treated as an angle, otherwise as pulse width in microseconds 
+  void writeMicroseconds(int value); // Write pulse width in microseconds 
+  int read();                        // returns current pulse width as an angle between 0 and 180 degrees
+  int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
+  bool attached();                   // return true if this servo is attached, otherwise false 
 private:
-	uint8_t servoIndex;               // index into the channel data for this servo
-	int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH    
-	int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH   
-	bool firstWrite;					 // need to know if this is the first write
+   uint8_t servoIndex;               // index into the channel data for this servo
+   int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH    
+   int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH   
+   bool firstWrite;                  // need to know if is the first write
 };
 
 #endif

--- a/src/Servo.h
+++ b/src/Servo.h
@@ -17,32 +17,32 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-/* 
-  A servo is activated by creating an instance of the Servo class passing 
+/*
+  A servo is activated by creating an instance of the Servo class passing
   the desired pin to the attach() method.
-  The servos are pulsed in the background using the value most recently 
+  The servos are pulsed in the background using the value most recently
   written using the write() method.
 
-  Note that analogWrite of PWM on pins associated with the timer are 
+  Note that analogWrite of PWM on pins associated with the timer are
   disabled when the first servo is attached.
-  Timers are seized as needed in groups of 12 servos - 24 servos use two 
+  Timers are seized as needed in groups of 12 servos - 24 servos use two
   timers, 48 servos will use four.
   The sequence used to sieze timers is defined in timers.h
 
   The methods are:
 
-    Servo - Class for manipulating servo motors connected to Arduino pins.
+	Servo - Class for manipulating servo motors connected to Arduino pins.
 
-    attach(pin )  - Attaches a servo motor to an i/o pin.
-    attach(pin, min, max  ) - Attaches to a pin setting min and max values in microseconds
-    default min is 544, max is 2400  
- 
-    write()     - Sets the servo angle in degrees.  (invalid angle that is valid as pulse in microseconds is treated as microseconds)
-    writeMicroseconds() - Sets the servo pulse width in microseconds 
-    read()      - Gets the last written servo pulse width as an angle between 0 and 180. 
-    readMicroseconds()   - Gets the last written servo pulse width in microseconds. (was read_us() in first release)
-    attached()  - Returns true if there is a servo attached. 
-    detach()    - Stops an attached servos from pulsing its i/o pin. 
+	attach(pin )  - Attaches a servo motor to an i/o pin.
+	attach(pin, min, max  ) - Attaches to a pin setting min and max values in microseconds
+	default min is 544, max is 2400
+
+	write()     - Sets the servo angle in degrees.  (invalid angle that is valid as pulse in microseconds is treated as microseconds)
+	writeMicroseconds() - Sets the servo pulse width in microseconds
+	read()      - Gets the last written servo pulse width as an angle between 0 and 180.
+	readMicroseconds()   - Gets the last written servo pulse width in microseconds. (was read_us() in first release)
+	attached()  - Returns true if there is a servo attached.
+	detach()    - Stops an attached servos from pulsing its i/o pin.
  */
 
 #ifndef Servo_h
@@ -50,15 +50,15 @@
 
 #include <inttypes.h>
 
-/* 
- * Defines for 16 bit timers used with  Servo library 
- *
- * If _useTimerX is defined then TimerX is a 16 bit timer on the current board
- * timer16_Sequence_t enumerates the sequence that the timers should be allocated
- * _Nbr_16timers indicates how many 16 bit timers are available.
- */
+ /*
+  * Defines for 16 bit timers used with  Servo library
+  *
+  * If _useTimerX is defined then TimerX is a 16 bit timer on the current board
+  * timer16_Sequence_t enumerates the sequence that the timers should be allocated
+  * _Nbr_16timers indicates how many 16 bit timers are available.
+  */
 
-// Architecture specific include
+  // Architecture specific include
 #if defined(ARDUINO_ARCH_AVR)
 #include "avr/ServoTimers.h"
 #elif defined(ARDUINO_ARCH_SAM)
@@ -89,32 +89,39 @@
 
 #if !defined(ARDUINO_ARCH_STM32F4)
 
-typedef struct  {
-  uint8_t nbr        :6 ;             // a pin number from 0 to 63
-  uint8_t isActive   :1 ;             // true if this channel is enabled, pin not pulsed if false 
-} ServoPin_t   ;  
+typedef struct {
+	uint8_t nbr : 6;             // a pin number from 0 to 63
+	uint8_t isActive : 1;             // true if this channel is enabled, pin not pulsed if false 
+} ServoPin_t;
 
 typedef struct {
-  ServoPin_t Pin;
-  volatile unsigned int ticks;
+	ServoPin_t Pin;
+	volatile unsigned int ticks;
 } servo_t;
+
+typedef struct {
+	volatile short int index[MAX_SERVOS];
+	volatile short int freePosition;
+	volatile short int actualPosition;
+} index_queue;
 
 class Servo
 {
 public:
-  Servo();
-  uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
-  uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes. 
-  void detach();
-  void write(int value);             // if value is < 200 its treated as an angle, otherwise as pulse width in microseconds 
-  void writeMicroseconds(int value); // Write pulse width in microseconds 
-  int read();                        // returns current pulse width as an angle between 0 and 180 degrees
-  int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
-  bool attached();                   // return true if this servo is attached, otherwise false 
+	Servo();
+	uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
+	uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes. 
+	void detach();
+	void write(int value);             // if value is < 200 its treated as an angle, otherwise as pulse width in microseconds 
+	void writeMicroseconds(int value); // Write pulse width in microseconds 
+	int read();                        // returns current pulse width as an angle between 0 and 180 degrees
+	int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
+	bool attached();                   // return true if this servo is attached, otherwise false 
 private:
-   uint8_t servoIndex;               // index into the channel data for this servo
-   int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH    
-   int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH   
+	uint8_t servoIndex;               // index into the channel data for this servo
+	int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH    
+	int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH   
+	bool firstWrite;					 // need to know if this is the first write
 };
 
 #endif

--- a/src/avr/Servo.cpp
+++ b/src/avr/Servo.cpp
@@ -30,12 +30,13 @@
 
 #define TRIM_DURATION       2                               // compensation ticks to trim adjust for digitalWrite delays // 12 August 2009
 
-//#define NBR_TIMERS        (MAX_SERVOS / SERVOS_PER_TIMER)
+ //#define NBR_TIMERS        (MAX_SERVOS / SERVOS_PER_TIMER)
 
 static servo_t servos[MAX_SERVOS];                          // static array of servo structures
-static volatile int8_t Channel[_Nbr_16timers ];             // counter for the servo being pulsed for each timer (or -1 if refresh interval)
-
+static volatile int8_t Channel[_Nbr_16timers];             // counter for the servo being pulsed for each timer (or -1 if refresh interval)
+index_queue queue;											// array of index ready to use
 uint8_t ServoCount = 0;                                     // the total number of attached servos
+bool queueInitialized = false;								// array of index initialized?
 
 
 // convenience macros
@@ -51,56 +52,56 @@ uint8_t ServoCount = 0;                                     // the total number 
 
 static inline void handle_interrupts(timer16_Sequence_t timer, volatile uint16_t *TCNTn, volatile uint16_t* OCRnA)
 {
-  if( Channel[timer] < 0 )
-    *TCNTn = 0; // channel set to -1 indicated that refresh interval completed so reset the timer
-  else{
-    if( SERVO_INDEX(timer,Channel[timer]) < ServoCount && SERVO(timer,Channel[timer]).Pin.isActive == true )
-      digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,LOW); // pulse this channel low if activated
-  }
+	if (Channel[timer] < 0)
+		*TCNTn = 0; // channel set to -1 indicated that refresh interval completed so reset the timer
+	else {
+		if (SERVO_INDEX(timer, Channel[timer]) < ServoCount && SERVO(timer, Channel[timer]).Pin.isActive == true)
+			digitalWrite(SERVO(timer, Channel[timer]).Pin.nbr, LOW); // pulse this channel low if activated
+	}
 
-  Channel[timer]++;    // increment to the next channel
-  if( SERVO_INDEX(timer,Channel[timer]) < ServoCount && Channel[timer] < SERVOS_PER_TIMER) {
-    *OCRnA = *TCNTn + SERVO(timer,Channel[timer]).ticks;
-    if(SERVO(timer,Channel[timer]).Pin.isActive == true)     // check if activated
-      digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,HIGH); // its an active channel so pulse it high
-  }
-  else {
-    // finished all channels so wait for the refresh period to expire before starting over
-    if( ((unsigned)*TCNTn) + 4 < usToTicks(REFRESH_INTERVAL) )  // allow a few ticks to ensure the next OCR1A not missed
-      *OCRnA = (unsigned int)usToTicks(REFRESH_INTERVAL);
-    else
-      *OCRnA = *TCNTn + 4;  // at least REFRESH_INTERVAL has elapsed
-    Channel[timer] = -1; // this will get incremented at the end of the refresh period to start again at the first channel
-  }
+	Channel[timer]++;    // increment to the next channel
+	if (SERVO_INDEX(timer, Channel[timer]) < ServoCount && Channel[timer] < SERVOS_PER_TIMER) {
+		*OCRnA = *TCNTn + SERVO(timer, Channel[timer]).ticks;
+		if (SERVO(timer, Channel[timer]).Pin.isActive == true)     // check if activated
+			digitalWrite(SERVO(timer, Channel[timer]).Pin.nbr, HIGH); // its an active channel so pulse it high
+	}
+	else {
+		// finished all channels so wait for the refresh period to expire before starting over
+		if (((unsigned)*TCNTn) + 4 < usToTicks(REFRESH_INTERVAL))  // allow a few ticks to ensure the next OCR1A not missed
+			*OCRnA = (unsigned int)usToTicks(REFRESH_INTERVAL);
+		else
+			*OCRnA = *TCNTn + 4;  // at least REFRESH_INTERVAL has elapsed
+		Channel[timer] = -1; // this will get incremented at the end of the refresh period to start again at the first channel
+	}
 }
 
 #ifndef WIRING // Wiring pre-defines signal handlers so don't define any if compiling for the Wiring platform
 // Interrupt handlers for Arduino
 #if defined(_useTimer1)
-SIGNAL (TIMER1_COMPA_vect)
+SIGNAL(TIMER1_COMPA_vect)
 {
-  handle_interrupts(_timer1, &TCNT1, &OCR1A);
+	handle_interrupts(_timer1, &TCNT1, &OCR1A);
 }
 #endif
 
 #if defined(_useTimer3)
-SIGNAL (TIMER3_COMPA_vect)
+SIGNAL(TIMER3_COMPA_vect)
 {
-  handle_interrupts(_timer3, &TCNT3, &OCR3A);
+	handle_interrupts(_timer3, &TCNT3, &OCR3A);
 }
 #endif
 
 #if defined(_useTimer4)
-SIGNAL (TIMER4_COMPA_vect)
+SIGNAL(TIMER4_COMPA_vect)
 {
-  handle_interrupts(_timer4, &TCNT4, &OCR4A);
+	handle_interrupts(_timer4, &TCNT4, &OCR4A);
 }
 #endif
 
 #if defined(_useTimer5)
-SIGNAL (TIMER5_COMPA_vect)
+SIGNAL(TIMER5_COMPA_vect)
 {
-  handle_interrupts(_timer5, &TCNT5, &OCR5A);
+	handle_interrupts(_timer5, &TCNT5, &OCR5A);
 }
 #endif
 
@@ -109,13 +110,13 @@ SIGNAL (TIMER5_COMPA_vect)
 #if defined(_useTimer1)
 void Timer1Service()
 {
-  handle_interrupts(_timer1, &TCNT1, &OCR1A);
+	handle_interrupts(_timer1, &TCNT1, &OCR1A);
 }
 #endif
 #if defined(_useTimer3)
 void Timer3Service()
 {
-  handle_interrupts(_timer3, &TCNT3, &OCR3A);
+	handle_interrupts(_timer3, &TCNT3, &OCR3A);
 }
 #endif
 #endif
@@ -124,194 +125,236 @@ void Timer3Service()
 static void initISR(timer16_Sequence_t timer)
 {
 #if defined (_useTimer1)
-  if(timer == _timer1) {
-    TCCR1A = 0;             // normal counting mode
-    TCCR1B = _BV(CS11);     // set prescaler of 8
-    TCNT1 = 0;              // clear the timer count
+	if (timer == _timer1) {
+		TCCR1A = 0;             // normal counting mode
+		TCCR1B = _BV(CS11);     // set prescaler of 8
+		TCNT1 = 0;              // clear the timer count
 #if defined(__AVR_ATmega8__)|| defined(__AVR_ATmega128__)
-    TIFR |= _BV(OCF1A);      // clear any pending interrupts;
-    TIMSK |=  _BV(OCIE1A) ;  // enable the output compare interrupt
+		TIFR |= _BV(OCF1A);      // clear any pending interrupts;
+		TIMSK |= _BV(OCIE1A);  // enable the output compare interrupt
 #else
-    // here if not ATmega8 or ATmega128
-    TIFR1 |= _BV(OCF1A);     // clear any pending interrupts;
-    TIMSK1 |=  _BV(OCIE1A) ; // enable the output compare interrupt
+	// here if not ATmega8 or ATmega128
+		TIFR1 |= _BV(OCF1A);     // clear any pending interrupts;
+		TIMSK1 |= _BV(OCIE1A); // enable the output compare interrupt
 #endif
 #if defined(WIRING)
-    timerAttach(TIMER1OUTCOMPAREA_INT, Timer1Service);
+		timerAttach(TIMER1OUTCOMPAREA_INT, Timer1Service);
 #endif
-  }
+	}
 #endif
 
 #if defined (_useTimer3)
-  if(timer == _timer3) {
-    TCCR3A = 0;             // normal counting mode
-    TCCR3B = _BV(CS31);     // set prescaler of 8
-    TCNT3 = 0;              // clear the timer count
+	if (timer == _timer3) {
+		TCCR3A = 0;             // normal counting mode
+		TCCR3B = _BV(CS31);     // set prescaler of 8
+		TCNT3 = 0;              // clear the timer count
 #if defined(__AVR_ATmega128__)
-    TIFR |= _BV(OCF3A);     // clear any pending interrupts;
-	ETIMSK |= _BV(OCIE3A);  // enable the output compare interrupt
+		TIFR |= _BV(OCF3A);     // clear any pending interrupts;
+		ETIMSK |= _BV(OCIE3A);  // enable the output compare interrupt
 #else
-    TIFR3 = _BV(OCF3A);     // clear any pending interrupts;
-    TIMSK3 =  _BV(OCIE3A) ; // enable the output compare interrupt
+		TIFR3 = _BV(OCF3A);     // clear any pending interrupts;
+		TIMSK3 = _BV(OCIE3A); // enable the output compare interrupt
 #endif
 #if defined(WIRING)
-    timerAttach(TIMER3OUTCOMPAREA_INT, Timer3Service);  // for Wiring platform only
+		timerAttach(TIMER3OUTCOMPAREA_INT, Timer3Service);  // for Wiring platform only
 #endif
-  }
+	}
 #endif
 
 #if defined (_useTimer4)
-  if(timer == _timer4) {
-    TCCR4A = 0;             // normal counting mode
-    TCCR4B = _BV(CS41);     // set prescaler of 8
-    TCNT4 = 0;              // clear the timer count
-    TIFR4 = _BV(OCF4A);     // clear any pending interrupts;
-    TIMSK4 =  _BV(OCIE4A) ; // enable the output compare interrupt
-  }
+	if (timer == _timer4) {
+		TCCR4A = 0;             // normal counting mode
+		TCCR4B = _BV(CS41);     // set prescaler of 8
+		TCNT4 = 0;              // clear the timer count
+		TIFR4 = _BV(OCF4A);     // clear any pending interrupts;
+		TIMSK4 = _BV(OCIE4A); // enable the output compare interrupt
+	}
 #endif
 
 #if defined (_useTimer5)
-  if(timer == _timer5) {
-    TCCR5A = 0;             // normal counting mode
-    TCCR5B = _BV(CS51);     // set prescaler of 8
-    TCNT5 = 0;              // clear the timer count
-    TIFR5 = _BV(OCF5A);     // clear any pending interrupts;
-    TIMSK5 =  _BV(OCIE5A) ; // enable the output compare interrupt
-  }
+	if (timer == _timer5) {
+		TCCR5A = 0;             // normal counting mode
+		TCCR5B = _BV(CS51);     // set prescaler of 8
+		TCNT5 = 0;              // clear the timer count
+		TIFR5 = _BV(OCF5A);     // clear any pending interrupts;
+		TIMSK5 = _BV(OCIE5A); // enable the output compare interrupt
+	}
 #endif
 }
 
 static void finISR(timer16_Sequence_t timer)
 {
-    //disable use of the given timer
+	//disable use of the given timer
 #if defined WIRING   // Wiring
-  if(timer == _timer1) {
-    #if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
-    TIMSK1 &=  ~_BV(OCIE1A) ;  // disable timer 1 output compare interrupt
-    #else
-    TIMSK &=  ~_BV(OCIE1A) ;  // disable timer 1 output compare interrupt
-    #endif
-    timerDetach(TIMER1OUTCOMPAREA_INT);
-  }
-  else if(timer == _timer3) {
-    #if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
-    TIMSK3 &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
-    #else
-    ETIMSK &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
-    #endif
-    timerDetach(TIMER3OUTCOMPAREA_INT);
-  }
+	if (timer == _timer1) {
+#if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
+		TIMSK1 &= ~_BV(OCIE1A);  // disable timer 1 output compare interrupt
+#else
+		TIMSK &= ~_BV(OCIE1A);  // disable timer 1 output compare interrupt
+#endif
+		timerDetach(TIMER1OUTCOMPAREA_INT);
+	}
+	else if (timer == _timer3) {
+#if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
+		TIMSK3 &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
+#else
+		ETIMSK &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
+#endif
+		timerDetach(TIMER3OUTCOMPAREA_INT);
+	}
 #else
   //For arduino - in future: call here to a currently undefined function to reset the timer
-  (void) timer;  // squash "unused parameter 'timer' [-Wunused-parameter]" warning
+	(void)timer;  // squash "unused parameter 'timer' [-Wunused-parameter]" warning
 #endif
 }
 
 static boolean isTimerActive(timer16_Sequence_t timer)
 {
-  // returns true if any servo is active on this timer
-  for(uint8_t channel=0; channel < SERVOS_PER_TIMER; channel++) {
-    if(SERVO(timer,channel).Pin.isActive == true)
-      return true;
-  }
-  return false;
+	// returns true if any servo is active on this timer
+	for (uint8_t channel = 0; channel < SERVOS_PER_TIMER; channel++) {
+		if (SERVO(timer, channel).Pin.isActive == true)
+			return true;
+	}
+	return false;
 }
 
+
+static void full_queue() {
+	if (!queueInitialized) {
+		queue.freePosition = 0;
+		queue.actualPosition = 0;
+		for (int i = 0; i < MAX_SERVOS; i++) {
+			queue.index[i] = i;
+		}
+		queueInitialized = true;
+	}
+}
 
 /****************** end of static functions ******************************/
 
-Servo::Servo()
-{
-  if( ServoCount < MAX_SERVOS) {
-    this->servoIndex = ServoCount++;                    // assign a servo index to this instance
-	servos[this->servoIndex].ticks = usToTicks(DEFAULT_PULSE_WIDTH);   // store default values  - 12 Aug 2009
-  }
-  else
-    this->servoIndex = INVALID_SERVO ;  // too many servos
-}
+//change location of variables
+Servo::Servo() {}
 
 uint8_t Servo::attach(int pin)
 {
-  return this->attach(pin, MIN_PULSE_WIDTH, MAX_PULSE_WIDTH);
+	return this->attach(pin, MIN_PULSE_WIDTH, MAX_PULSE_WIDTH);
 }
 
 uint8_t Servo::attach(int pin, int min, int max)
 {
-  if(this->servoIndex < MAX_SERVOS ) {
-    pinMode( pin, OUTPUT) ;                                   // set servo pin to output
-    servos[this->servoIndex].Pin.nbr = pin;
-    // todo min/max check: abs(min - MIN_PULSE_WIDTH) /4 < 128
-    this->min  = (MIN_PULSE_WIDTH - min)/4; //resolution of min/max is 4 uS
-    this->max  = (MAX_PULSE_WIDTH - max)/4;
-    // initialize the timer if it has not already been initialized
-    timer16_Sequence_t timer = SERVO_INDEX_TO_TIMER(servoIndex);
-    if(isTimerActive(timer) == false)
-      initISR(timer);
-    servos[this->servoIndex].Pin.isActive = true;  // this must be set after the check for isTimerActive
-  }
-  return this->servoIndex ;
+	if (!queueInitialized)
+	{
+		full_queue();
+	}
+	if (ServoCount < MAX_SERVOS)
+	{
+		//stack control of the timer association
+		this->servoIndex = queue.index[queue.actualPosition];                // assign a servo index to this instance
+		queue.index[queue.actualPosition] = -1;								 // empty index now
+		actualPosition = (actualPosition + 1) % MAX_SERVOS;
+		ServoCount++;
+		//line deleted
+		//servos[this->servoIndex].ticks = usToTicks(DEFAULT_PULSE_WIDTH);   // store default values  - 12 Aug 2009
+	}
+	else
+		this->servoIndex = INVALID_SERVO;  // too many servos
+	if (this->servoIndex < MAX_SERVOS) {
+		pinMode(pin, OUTPUT);                                   // set servo pin to output
+		servos[this->servoIndex].Pin.nbr = pin;
+		// todo min/max check: abs(min - MIN_PULSE_WIDTH) /4 < 128
+		this->min = (MIN_PULSE_WIDTH - min) / 4; //resolution of min/max is 4 uS
+		this->max = (MAX_PULSE_WIDTH - max) / 4;
+		// initialize the timer if it has not already been initialized
+		timer16_Sequence_t timer = SERVO_INDEX_TO_TIMER(servoIndex);
+		if (isTimerActive(timer) == false)
+			initISR(timer);
+		//change location in writeMicroseconds
+		//servos[this->servoIndex].Pin.isActive = true;  // this must be set after the check for isTimerActive
+		this->firstWrite = true;
+	}
+	return this->servoIndex;
 }
 
 void Servo::detach()
 {
-  servos[this->servoIndex].Pin.isActive = false;
-  timer16_Sequence_t timer = SERVO_INDEX_TO_TIMER(servoIndex);
-  if(isTimerActive(timer) == false) {
-    finISR(timer);
-  }
+	timer16_Sequence_t timer;
+	if (this->servoIndex < MAX_SERVOS) {
+		//stack control of the timer association
+		servos[this->servoIndex].Pin.isActive = false;
+		servos[this->servoIndex].ticks = 0;
+		timer = SERVO_INDEX_TO_TIMER(servoIndex);
+
+		queue.index[queue.freePosition] = this->servoIndex;
+		queue.freePosition = (queue.freePosition + 1) % MAX_SERVOS;
+		ServoCount--;
+		this->servoIndex = -1;
+	}
+
+	if (isTimerActive(timer) == false) {
+		finISR(timer);
+	}
 }
 
 void Servo::write(int value)
 {
-  if(value < MIN_PULSE_WIDTH)
-  {  // treat values less than 544 as angles in degrees (valid values in microseconds are handled as microseconds)
-    if(value < 0) value = 0;
-    if(value > 180) value = 180;
-    value = map(value, 0, 180, SERVO_MIN(),  SERVO_MAX());
-  }
-  this->writeMicroseconds(value);
+	if (value < MIN_PULSE_WIDTH)
+	{  // treat values less than 544 as angles in degrees (valid values in microseconds are handled as microseconds)
+		if (value < 0) value = 0;
+		if (value > 180) value = 180;
+		value = map(value, 0, 180, SERVO_MIN(), SERVO_MAX());
+	}
+	this->writeMicroseconds(value);
 }
 
 void Servo::writeMicroseconds(int value)
 {
-  // calculate and store the values for the given channel
-  byte channel = this->servoIndex;
-  if( (channel < MAX_SERVOS) )   // ensure channel is valid
-  {
-    if( value < SERVO_MIN() )          // ensure pulse width is valid
-      value = SERVO_MIN();
-    else if( value > SERVO_MAX() )
-      value = SERVO_MAX();
+	if (this->firstWrite)
+	{
+		servos[this->servoIndex].Pin.isActive = true;
+		this->firstWrite = false;
+	}
+	// calculate and store the values for the given channel
+	byte channel = this->servoIndex;
+	if ((channel < MAX_SERVOS))   // ensure channel is valid
+	{
+		if (value < SERVO_MIN())          // ensure pulse width is valid
+			value = SERVO_MIN();
+		else if (value > SERVO_MAX())
+			value = SERVO_MAX();
 
-    value = value - TRIM_DURATION;
-    value = usToTicks(value);  // convert to ticks after compensating for interrupt overhead - 12 Aug 2009
+		value = value - TRIM_DURATION;
+		value = usToTicks(value);  // convert to ticks after compensating for interrupt overhead - 12 Aug 2009
 
-    uint8_t oldSREG = SREG;
-    cli();
-    servos[channel].ticks = value;
-    SREG = oldSREG;
-  }
+		uint8_t oldSREG = SREG;
+		cli();
+		servos[channel].ticks = value;
+		SREG = oldSREG;
+	}
 }
 
 int Servo::read() // return the value as degrees
 {
-  return  map( this->readMicroseconds()+1, SERVO_MIN(), SERVO_MAX(), 0, 180);
+	if (this->firstWrite)
+		return -1;
+	return  map(this->readMicroseconds() + 1, SERVO_MIN(), SERVO_MAX(), 0, 180);
 }
 
 int Servo::readMicroseconds()
 {
-  unsigned int pulsewidth;
-  if( this->servoIndex != INVALID_SERVO )
-    pulsewidth = ticksToUs(servos[this->servoIndex].ticks)  + TRIM_DURATION ;   // 12 aug 2009
-  else
-    pulsewidth  = 0;
+	if (this->firstWrite)
+		return -1;
+	unsigned int pulsewidth;
+	if (this->servoIndex != INVALID_SERVO)
+		pulsewidth = ticksToUs(servos[this->servoIndex].ticks) + TRIM_DURATION;   // 12 aug 2009
+	else
+		pulsewidth = 0;
 
-  return pulsewidth;
+	return pulsewidth;
 }
 
 bool Servo::attached()
 {
-  return servos[this->servoIndex].Pin.isActive ;
+	return servos[this->servoIndex].Pin.isActive;
 }
 
 #endif // ARDUINO_ARCH_AVR

--- a/src/avr/Servo.cpp
+++ b/src/avr/Servo.cpp
@@ -30,13 +30,12 @@
 
 #define TRIM_DURATION       2                               // compensation ticks to trim adjust for digitalWrite delays // 12 August 2009
 
- //#define NBR_TIMERS        (MAX_SERVOS / SERVOS_PER_TIMER)
+//#define NBR_TIMERS        (MAX_SERVOS / SERVOS_PER_TIMER)
 
 static servo_t servos[MAX_SERVOS];                          // static array of servo structures
-static volatile int8_t Channel[_Nbr_16timers];             // counter for the servo being pulsed for each timer (or -1 if refresh interval)
-index_queue queue;											// array of index ready to use
+static volatile int8_t Channel[_Nbr_16timers ];             // counter for the servo being pulsed for each timer (or -1 if refresh interval)
+
 uint8_t ServoCount = 0;                                     // the total number of attached servos
-bool queueInitialized = false;								// array of index initialized?
 
 
 // convenience macros
@@ -52,56 +51,56 @@ bool queueInitialized = false;								// array of index initialized?
 
 static inline void handle_interrupts(timer16_Sequence_t timer, volatile uint16_t *TCNTn, volatile uint16_t* OCRnA)
 {
-	if (Channel[timer] < 0)
-		*TCNTn = 0; // channel set to -1 indicated that refresh interval completed so reset the timer
-	else {
-		if (SERVO_INDEX(timer, Channel[timer]) < ServoCount && SERVO(timer, Channel[timer]).Pin.isActive == true)
-			digitalWrite(SERVO(timer, Channel[timer]).Pin.nbr, LOW); // pulse this channel low if activated
-	}
+  if( Channel[timer] < 0 )
+    *TCNTn = 0; // channel set to -1 indicated that refresh interval completed so reset the timer
+  else{
+    if( SERVO_INDEX(timer,Channel[timer]) < ServoCount && SERVO(timer,Channel[timer]).Pin.isActive == true )
+      digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,LOW); // pulse this channel low if activated
+  }
 
-	Channel[timer]++;    // increment to the next channel
-	if (SERVO_INDEX(timer, Channel[timer]) < ServoCount && Channel[timer] < SERVOS_PER_TIMER) {
-		*OCRnA = *TCNTn + SERVO(timer, Channel[timer]).ticks;
-		if (SERVO(timer, Channel[timer]).Pin.isActive == true)     // check if activated
-			digitalWrite(SERVO(timer, Channel[timer]).Pin.nbr, HIGH); // its an active channel so pulse it high
-	}
-	else {
-		// finished all channels so wait for the refresh period to expire before starting over
-		if (((unsigned)*TCNTn) + 4 < usToTicks(REFRESH_INTERVAL))  // allow a few ticks to ensure the next OCR1A not missed
-			*OCRnA = (unsigned int)usToTicks(REFRESH_INTERVAL);
-		else
-			*OCRnA = *TCNTn + 4;  // at least REFRESH_INTERVAL has elapsed
-		Channel[timer] = -1; // this will get incremented at the end of the refresh period to start again at the first channel
-	}
+  Channel[timer]++;    // increment to the next channel
+  if( SERVO_INDEX(timer,Channel[timer]) < ServoCount && Channel[timer] < SERVOS_PER_TIMER) {
+    *OCRnA = *TCNTn + SERVO(timer,Channel[timer]).ticks;
+    if(SERVO(timer,Channel[timer]).Pin.isActive == true)     // check if activated
+      digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,HIGH); // its an active channel so pulse it high
+  }
+  else {
+    // finished all channels so wait for the refresh period to expire before starting over
+    if( ((unsigned)*TCNTn) + 4 < usToTicks(REFRESH_INTERVAL) )  // allow a few ticks to ensure the next OCR1A not missed
+      *OCRnA = (unsigned int)usToTicks(REFRESH_INTERVAL);
+    else
+      *OCRnA = *TCNTn + 4;  // at least REFRESH_INTERVAL has elapsed
+    Channel[timer] = -1; // this will get incremented at the end of the refresh period to start again at the first channel
+  }
 }
 
 #ifndef WIRING // Wiring pre-defines signal handlers so don't define any if compiling for the Wiring platform
 // Interrupt handlers for Arduino
 #if defined(_useTimer1)
-SIGNAL(TIMER1_COMPA_vect)
+SIGNAL (TIMER1_COMPA_vect)
 {
-	handle_interrupts(_timer1, &TCNT1, &OCR1A);
+  handle_interrupts(_timer1, &TCNT1, &OCR1A);
 }
 #endif
 
 #if defined(_useTimer3)
-SIGNAL(TIMER3_COMPA_vect)
+SIGNAL (TIMER3_COMPA_vect)
 {
-	handle_interrupts(_timer3, &TCNT3, &OCR3A);
+  handle_interrupts(_timer3, &TCNT3, &OCR3A);
 }
 #endif
 
 #if defined(_useTimer4)
-SIGNAL(TIMER4_COMPA_vect)
+SIGNAL (TIMER4_COMPA_vect)
 {
-	handle_interrupts(_timer4, &TCNT4, &OCR4A);
+  handle_interrupts(_timer4, &TCNT4, &OCR4A);
 }
 #endif
 
 #if defined(_useTimer5)
-SIGNAL(TIMER5_COMPA_vect)
+SIGNAL (TIMER5_COMPA_vect)
 {
-	handle_interrupts(_timer5, &TCNT5, &OCR5A);
+  handle_interrupts(_timer5, &TCNT5, &OCR5A);
 }
 #endif
 
@@ -110,13 +109,13 @@ SIGNAL(TIMER5_COMPA_vect)
 #if defined(_useTimer1)
 void Timer1Service()
 {
-	handle_interrupts(_timer1, &TCNT1, &OCR1A);
+  handle_interrupts(_timer1, &TCNT1, &OCR1A);
 }
 #endif
 #if defined(_useTimer3)
 void Timer3Service()
 {
-	handle_interrupts(_timer3, &TCNT3, &OCR3A);
+  handle_interrupts(_timer3, &TCNT3, &OCR3A);
 }
 #endif
 #endif
@@ -125,236 +124,209 @@ void Timer3Service()
 static void initISR(timer16_Sequence_t timer)
 {
 #if defined (_useTimer1)
-	if (timer == _timer1) {
-		TCCR1A = 0;             // normal counting mode
-		TCCR1B = _BV(CS11);     // set prescaler of 8
-		TCNT1 = 0;              // clear the timer count
+  if(timer == _timer1) {
+    TCCR1A = 0;             // normal counting mode
+    TCCR1B = _BV(CS11);     // set prescaler of 8
+    TCNT1 = 0;              // clear the timer count
 #if defined(__AVR_ATmega8__)|| defined(__AVR_ATmega128__)
-		TIFR |= _BV(OCF1A);      // clear any pending interrupts;
-		TIMSK |= _BV(OCIE1A);  // enable the output compare interrupt
+    TIFR |= _BV(OCF1A);      // clear any pending interrupts;
+    TIMSK |=  _BV(OCIE1A) ;  // enable the output compare interrupt
 #else
-	// here if not ATmega8 or ATmega128
-		TIFR1 |= _BV(OCF1A);     // clear any pending interrupts;
-		TIMSK1 |= _BV(OCIE1A); // enable the output compare interrupt
+    // here if not ATmega8 or ATmega128
+    TIFR1 |= _BV(OCF1A);     // clear any pending interrupts;
+    TIMSK1 |=  _BV(OCIE1A) ; // enable the output compare interrupt
 #endif
 #if defined(WIRING)
-		timerAttach(TIMER1OUTCOMPAREA_INT, Timer1Service);
+    timerAttach(TIMER1OUTCOMPAREA_INT, Timer1Service);
 #endif
-	}
+  }
 #endif
 
 #if defined (_useTimer3)
-	if (timer == _timer3) {
-		TCCR3A = 0;             // normal counting mode
-		TCCR3B = _BV(CS31);     // set prescaler of 8
-		TCNT3 = 0;              // clear the timer count
+  if(timer == _timer3) {
+    TCCR3A = 0;             // normal counting mode
+    TCCR3B = _BV(CS31);     // set prescaler of 8
+    TCNT3 = 0;              // clear the timer count
 #if defined(__AVR_ATmega128__)
-		TIFR |= _BV(OCF3A);     // clear any pending interrupts;
-		ETIMSK |= _BV(OCIE3A);  // enable the output compare interrupt
+    TIFR |= _BV(OCF3A);     // clear any pending interrupts;
+	ETIMSK |= _BV(OCIE3A);  // enable the output compare interrupt
 #else
-		TIFR3 = _BV(OCF3A);     // clear any pending interrupts;
-		TIMSK3 = _BV(OCIE3A); // enable the output compare interrupt
+    TIFR3 = _BV(OCF3A);     // clear any pending interrupts;
+    TIMSK3 =  _BV(OCIE3A) ; // enable the output compare interrupt
 #endif
 #if defined(WIRING)
-		timerAttach(TIMER3OUTCOMPAREA_INT, Timer3Service);  // for Wiring platform only
+    timerAttach(TIMER3OUTCOMPAREA_INT, Timer3Service);  // for Wiring platform only
 #endif
-	}
+  }
 #endif
 
 #if defined (_useTimer4)
-	if (timer == _timer4) {
-		TCCR4A = 0;             // normal counting mode
-		TCCR4B = _BV(CS41);     // set prescaler of 8
-		TCNT4 = 0;              // clear the timer count
-		TIFR4 = _BV(OCF4A);     // clear any pending interrupts;
-		TIMSK4 = _BV(OCIE4A); // enable the output compare interrupt
-	}
+  if(timer == _timer4) {
+    TCCR4A = 0;             // normal counting mode
+    TCCR4B = _BV(CS41);     // set prescaler of 8
+    TCNT4 = 0;              // clear the timer count
+    TIFR4 = _BV(OCF4A);     // clear any pending interrupts;
+    TIMSK4 =  _BV(OCIE4A) ; // enable the output compare interrupt
+  }
 #endif
 
 #if defined (_useTimer5)
-	if (timer == _timer5) {
-		TCCR5A = 0;             // normal counting mode
-		TCCR5B = _BV(CS51);     // set prescaler of 8
-		TCNT5 = 0;              // clear the timer count
-		TIFR5 = _BV(OCF5A);     // clear any pending interrupts;
-		TIMSK5 = _BV(OCIE5A); // enable the output compare interrupt
-	}
+  if(timer == _timer5) {
+    TCCR5A = 0;             // normal counting mode
+    TCCR5B = _BV(CS51);     // set prescaler of 8
+    TCNT5 = 0;              // clear the timer count
+    TIFR5 = _BV(OCF5A);     // clear any pending interrupts;
+    TIMSK5 =  _BV(OCIE5A) ; // enable the output compare interrupt
+  }
 #endif
 }
 
 static void finISR(timer16_Sequence_t timer)
 {
-	//disable use of the given timer
+    //disable use of the given timer
 #if defined WIRING   // Wiring
-	if (timer == _timer1) {
-#if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
-		TIMSK1 &= ~_BV(OCIE1A);  // disable timer 1 output compare interrupt
-#else
-		TIMSK &= ~_BV(OCIE1A);  // disable timer 1 output compare interrupt
-#endif
-		timerDetach(TIMER1OUTCOMPAREA_INT);
-	}
-	else if (timer == _timer3) {
-#if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
-		TIMSK3 &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
-#else
-		ETIMSK &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
-#endif
-		timerDetach(TIMER3OUTCOMPAREA_INT);
-	}
+  if(timer == _timer1) {
+    #if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
+    TIMSK1 &=  ~_BV(OCIE1A) ;  // disable timer 1 output compare interrupt
+    #else
+    TIMSK &=  ~_BV(OCIE1A) ;  // disable timer 1 output compare interrupt
+    #endif
+    timerDetach(TIMER1OUTCOMPAREA_INT);
+  }
+  else if(timer == _timer3) {
+    #if defined(__AVR_ATmega1281__)||defined(__AVR_ATmega2561__)
+    TIMSK3 &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
+    #else
+    ETIMSK &= ~_BV(OCIE3A);    // disable the timer3 output compare A interrupt
+    #endif
+    timerDetach(TIMER3OUTCOMPAREA_INT);
+  }
 #else
   //For arduino - in future: call here to a currently undefined function to reset the timer
-	(void)timer;  // squash "unused parameter 'timer' [-Wunused-parameter]" warning
+  (void) timer;  // squash "unused parameter 'timer' [-Wunused-parameter]" warning
 #endif
 }
 
 static boolean isTimerActive(timer16_Sequence_t timer)
 {
-	// returns true if any servo is active on this timer
-	for (uint8_t channel = 0; channel < SERVOS_PER_TIMER; channel++) {
-		if (SERVO(timer, channel).Pin.isActive == true)
-			return true;
-	}
-	return false;
-}
-
-
-static void full_queue() {
-	if (!queueInitialized) {
-		queue.freePosition = 0;
-		queue.actualPosition = 0;
-		for (int i = 0; i < MAX_SERVOS; i++) {
-			queue.index[i] = i;
-		}
-		queueInitialized = true;
-	}
+  // returns true if any servo is active on this timer
+  for(uint8_t channel=0; channel < SERVOS_PER_TIMER; channel++) {
+    if(SERVO(timer,channel).Pin.isActive == true)
+      return true;
+  }
+  return false;
 }
 
 /****************** end of static functions ******************************/
 
-//change location of variables
-Servo::Servo() {}
+Servo::Servo(){}
 
 uint8_t Servo::attach(int pin)
 {
-	return this->attach(pin, MIN_PULSE_WIDTH, MAX_PULSE_WIDTH);
+  return this->attach(pin, MIN_PULSE_WIDTH, MAX_PULSE_WIDTH);
 }
 
 uint8_t Servo::attach(int pin, int min, int max)
 {
-	if (!queueInitialized)
-	{
-		full_queue();
-	}
-	if (ServoCount < MAX_SERVOS)
-	{
-		//stack control of the timer association
-		this->servoIndex = queue.index[queue.actualPosition];                // assign a servo index to this instance
-		queue.index[queue.actualPosition] = -1;								 // empty index now
-		actualPosition = (actualPosition + 1) % MAX_SERVOS;
-		ServoCount++;
-		//line deleted
-		//servos[this->servoIndex].ticks = usToTicks(DEFAULT_PULSE_WIDTH);   // store default values  - 12 Aug 2009
-	}
-	else
-		this->servoIndex = INVALID_SERVO;  // too many servos
-	if (this->servoIndex < MAX_SERVOS) {
-		pinMode(pin, OUTPUT);                                   // set servo pin to output
-		servos[this->servoIndex].Pin.nbr = pin;
-		// todo min/max check: abs(min - MIN_PULSE_WIDTH) /4 < 128
-		this->min = (MIN_PULSE_WIDTH - min) / 4; //resolution of min/max is 4 uS
-		this->max = (MAX_PULSE_WIDTH - max) / 4;
-		// initialize the timer if it has not already been initialized
-		timer16_Sequence_t timer = SERVO_INDEX_TO_TIMER(servoIndex);
-		if (isTimerActive(timer) == false)
-			initISR(timer);
-		//change location in writeMicroseconds
-		//servos[this->servoIndex].Pin.isActive = true;  // this must be set after the check for isTimerActive
-		this->firstWrite = true;
-	}
-	return this->servoIndex;
+  if (ServoCount < MAX_SERVOS) {
+    //queue control of the timer association
+    this->servoIndex = ServoCount++;
+  }
+  else
+    this->servoIndex = INVALID_SERVO;
+  if(this->servoIndex < MAX_SERVOS ) {
+    pinMode( pin, OUTPUT) ;                                   // set servo pin to output
+    servos[this->servoIndex].Pin.nbr = pin;
+    // todo min/max check: abs(min - MIN_PULSE_WIDTH) /4 < 128
+    this->min  = (MIN_PULSE_WIDTH - min)/4; //resolution of min/max is 4 uS
+    this->max  = (MAX_PULSE_WIDTH - max)/4;
+    // initialize the timer if it has not already been initialized
+    timer16_Sequence_t timer = SERVO_INDEX_TO_TIMER(servoIndex);
+    if(isTimerActive(timer) == false)
+      initISR(timer);
+    servos[this->servoIndex].Pin.isActive = true;  // this must be set after the check for isTimerActive
+  }
+  return this->servoIndex ;
 }
 
 void Servo::detach()
-{
-	timer16_Sequence_t timer;
-	if (this->servoIndex < MAX_SERVOS) {
-		//stack control of the timer association
-		servos[this->servoIndex].Pin.isActive = false;
-		servos[this->servoIndex].ticks = 0;
-		timer = SERVO_INDEX_TO_TIMER(servoIndex);
-
-		queue.index[queue.freePosition] = this->servoIndex;
-		queue.freePosition = (queue.freePosition + 1) % MAX_SERVOS;
-		ServoCount--;
-		this->servoIndex = -1;
-	}
-
-	if (isTimerActive(timer) == false) {
-		finISR(timer);
-	}
+{  
+  timer16_Sequence_t timer ;
+  if(this->servoIndex<MAX_SERVOS){
+    servos[this->servoIndex].Pin.isActive=servos[ServoCount-1].Pin.isActive;
+    servos[this->servoIndex].ticks=servos[ServoCount-1].Pin.nbr;
+    servos[this->servoIndex].ticks = servos[ServoCount--].ticks;
+    timer=SERVO_INDEX_TO_TIMER(servoIndex);
+    
+    this->servoIndex=-1;
+  }else
+    return;
+  if(isTimerActive(timer) == false) {
+    finISR(timer);
+  }
 }
 
 void Servo::write(int value)
 {
-	if (value < MIN_PULSE_WIDTH)
-	{  // treat values less than 544 as angles in degrees (valid values in microseconds are handled as microseconds)
-		if (value < 0) value = 0;
-		if (value > 180) value = 180;
-		value = map(value, 0, 180, SERVO_MIN(), SERVO_MAX());
-	}
-	this->writeMicroseconds(value);
+  if(value < MIN_PULSE_WIDTH)
+  {  // treat values less than 544 as angles in degrees (valid values in microseconds are handled as microseconds)
+    if(value < 0) value = 0;
+    if(value > 180) value = 180;
+    value = map(value, 0, 180, SERVO_MIN(),  SERVO_MAX());
+  }
+  this->writeMicroseconds(value);
 }
 
 void Servo::writeMicroseconds(int value)
 {
-	if (this->firstWrite)
-	{
-		servos[this->servoIndex].Pin.isActive = true;
-		this->firstWrite = false;
-	}
-	// calculate and store the values for the given channel
-	byte channel = this->servoIndex;
-	if ((channel < MAX_SERVOS))   // ensure channel is valid
-	{
-		if (value < SERVO_MIN())          // ensure pulse width is valid
-			value = SERVO_MIN();
-		else if (value > SERVO_MAX())
-			value = SERVO_MAX();
+  if(this->firstWrite){
+    servos[this->servoIndex].Pin.isActive=true;
+    this->firstWrite=false;
+  }
+  // calculate and store the values for the given channel
+  byte channel = this->servoIndex;
+  if( (channel < MAX_SERVOS) )   // ensure channel is valid
+  {
+    if( value < SERVO_MIN() )          // ensure pulse width is valid
+      value = SERVO_MIN();
+    else if( value > SERVO_MAX() )
+      value = SERVO_MAX();
 
-		value = value - TRIM_DURATION;
-		value = usToTicks(value);  // convert to ticks after compensating for interrupt overhead - 12 Aug 2009
+    value = value - TRIM_DURATION;
+    value = usToTicks(value);  // convert to ticks after compensating for interrupt overhead - 12 Aug 2009
 
-		uint8_t oldSREG = SREG;
-		cli();
-		servos[channel].ticks = value;
-		SREG = oldSREG;
-	}
+    uint8_t oldSREG = SREG;
+    cli();
+    servos[channel].ticks = value;
+    SREG = oldSREG;
+  }
 }
 
 int Servo::read() // return the value as degrees
 {
-	if (this->firstWrite)
-		return -1;
-	return  map(this->readMicroseconds() + 1, SERVO_MIN(), SERVO_MAX(), 0, 180);
+  if(this->firstWrite){
+    return -1;
+  }
+  return  map( this->readMicroseconds()+1, SERVO_MIN(), SERVO_MAX(), 0, 180);
 }
 
 int Servo::readMicroseconds()
 {
-	if (this->firstWrite)
-		return -1;
-	unsigned int pulsewidth;
-	if (this->servoIndex != INVALID_SERVO)
-		pulsewidth = ticksToUs(servos[this->servoIndex].ticks) + TRIM_DURATION;   // 12 aug 2009
-	else
-		pulsewidth = 0;
+  if(this->firstWrite){
+    return -1;
+  }
+  unsigned int pulsewidth;
+  if( this->servoIndex != INVALID_SERVO )
+    pulsewidth = ticksToUs(servos[this->servoIndex].ticks)  + TRIM_DURATION ;   // 12 aug 2009
+  else
+    pulsewidth  = 0;
 
-	return pulsewidth;
+  return pulsewidth;
 }
 
 bool Servo::attached()
 {
-	return servos[this->servoIndex].Pin.isActive;
+  return servos[this->servoIndex].Pin.isActive ;
 }
 
 #endif // ARDUINO_ARCH_AVR


### PR DESCRIPTION
I removed default pwm value from constructor and moved servoIndex assignament into attach method.

I removed from attach method the enable of the pin. It's now enabled only after
the first write is called, to avoid initial unwanted pwm output.

I modified the read function. Now return -1 if the user hasn't written any value before.

I changed also the attach/detach functions:
Attach gets the Servo index from a indexes queue that is updated when detach occurs in order to make the index used by Servo
available again.