### PR TITLE
Add #include directive for megaAVR dependency

### DIFF
--- a/src/megaavr/ServoTimers.h
+++ b/src/megaavr/ServoTimers.h
@@ -24,6 +24,8 @@
 #ifndef __SERVO_TIMERS_H__
 #define __SERVO_TIMERS_H__
 
+#include <avr/io.h>
+
 #define USE_TIMERB1        // interferes with PWM on pin 3
 //#define USE_TIMERB2        // interferes with PWM on pin 11
 //#define USE_TIMERB0        // interferes with PWM on pin 6


### PR DESCRIPTION
The `TCB_t` type used in the megaAVR version of the library is declared via avr/io.h, but the Servo library does not contain an `#include` directive for this file. This is not a problem when the library is used in a .ino file, since Arduino.h does contain an `#include` directive for that file and the sketch preprocessor should insert the `#include` directive for Arduino.h above the `#include` directive for Servo.h. However, if the Servo library is instead used from a separate translation unit, the dependency was missing and compilation for megaAVR failed:
```
E:\arduino\libraries\Servo\src/megaavr/ServoTimers.h:36:17: error: 'TCB_t' does not name a type

 static volatile TCB_t* _timer =

                 ^
```

Fixes https://github.com/arduino-libraries/Servo/issues/26

CC: @kungfupizza