### PR TITLE
change timer to allow Servo + Tone interaction

### DIFF
--- a/src/megaavr/ServoTimers.h
+++ b/src/megaavr/ServoTimers.h
@@ -26,8 +26,8 @@
 
 #include <avr/io.h>
 
-#define USE_TIMERB1        // interferes with PWM on pin 3
-//#define USE_TIMERB2        // interferes with PWM on pin 11
+//#define USE_TIMERB1        // interferes with PWM on pin 3
+#define USE_TIMERB2        // interferes with PWM on pin 11
 //#define USE_TIMERB0        // interferes with PWM on pin 6
 
 #if !defined(USE_TIMERB1) && !defined(USE_TIMERB2) && !defined(USE_TIMERB0)


### PR DESCRIPTION
Fixes issue https://github.com/arduino/Arduino/issues/9122 when using Servo and Tone with megaavr4089.

If there is no immediate incompatibilities, this should be approved as it affects e.g. the EduIntro library, which is used for super-fast introduction workshops.