### PR TITLE
[megaAVR] reduce time distance between pulses

### DIFF
--- a/src/megaavr/Servo.cpp
+++ b/src/megaavr/Servo.cpp
@@ -23,6 +23,9 @@ static volatile int8_t currentServoIndex[_Nbr_16timers];   // index for the serv
 #define SERVO_MIN() (MIN_PULSE_WIDTH - this->min * 4)   // minimum value in uS for this servo
 #define SERVO_MAX() (MAX_PULSE_WIDTH - this->max * 4)   // maximum value in uS for this servo
 
+#undef REFRESH_INTERVAL
+#define REFRESH_INTERVAL 16000
+
 void ServoHandler(int timer)
 {
     if (currentServoIndex[timer] < 0) {


### PR DESCRIPTION
Using [FEETECH 2CH Servo Motor Controller for DC Motor](https://forums.parallax.com/discussion/download/118360/FT-SMC-2CH.pdf) a shorter distance between pulses is needed to achieve correct functionality.
This patch does not affect normal Servo operations

Fixes https://github.com/arduino-libraries/Servo/issues/31