### PR TITLE
Use unambiguous pin name for Knob example's analog input

### DIFF
--- a/examples/Knob/Knob.ino
+++ b/examples/Knob/Knob.ino
@@ -11,7 +11,7 @@
 
 Servo myservo;  // create servo object to control a servo
 
-int potpin = 0;  // analog pin used to connect the potentiometer
+int potpin = A0;  // analog pin used to connect the potentiometer
 int val;    // variable to read the value from the analog pin
 
 void setup() {


### PR DESCRIPTION
The previous use of "0" for the potentiometer pin can be a source of confusion because the correct connection is not to the pin on the board marked "0".

Although analogRead() supports either analog channel number or pin name, it is most user friendly to use the pin name as it is labeled on the Arduino boards.

This change is compatible with [the tutorial](https://github.com/arduino-libraries/Servo/tree/master/examples/Knob), which shows the pin as "A0" in the schematic, and refers to it as "analog input 0" in the description.

---
Fixes https://github.com/arduino/Arduino/issues/8042