### PR TITLE
Correct erroneous comment re: `Servo::attach` return

### DIFF
--- a/src/Servo.h
+++ b/src/Servo.h
@@ -105,7 +105,7 @@ class Servo
 {
 public:
   Servo();
-  uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or 0 if failure
+  uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or INVALID_SERVO if failure
   uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes. 
   void detach();
   void write(int value);             // if value is < 200 its treated as an angle, otherwise as pulse width in microseconds 


### PR DESCRIPTION
The comment claimed that 0 was returned by `Servo::attach` on failure. This is incorrect. The return value is the channel number, which is 0 for the `Servo` object that is instantiated first.

Instead, `INVALID_SERVO` (defined as 255) is returned [on failure](https://github.com/arduino-libraries/Servo/blob/f3617664917ff1a46c2c3db5300d27054ba147cc/src/avr/Servo.cpp#L230).

Fixes https://github.com/arduino-libraries/Servo/issues/85
CC: @BanksySan
