### PR TITLE
Fix min/max private variables overflow

### DIFF
--- a/src/Servo.h
+++ b/src/Servo.h
@@ -115,8 +115,8 @@ public:
   bool attached();                   // return true if this servo is attached, otherwise false 
 private:
    uint8_t servoIndex;               // index into the channel data for this servo
-   int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH    
-   int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH   
+   int min;                          // minimum is this value times 4 added to MIN_PULSE_WIDTH    
+   int max;                          // maximum is this value times 4 added to MAX_PULSE_WIDTH   
 };
 
 #endif


### PR DESCRIPTION
Using an `int8_t` for `min` and `max` causes the computation of `this->min` and `this->max` in `Servo::attach(int pin, int min, int max)` to overflow (for instance when calling `my_servo.attach(my_pin, 544, 1100)`, following https://www.arduino.cc/reference/en/libraries/servo/attach/).