### PR TITLE
`readMicroseconds()` affine transformation

### DIFF
--- a/src/mbed/Servo.cpp
+++ b/src/mbed/Servo.cpp
@@ -128,7 +128,7 @@ int Servo::readMicroseconds()
   if (!servos[this->servoIndex]) {
     return 0;
   }
-  return servos[this->servoIndex]->duration;
+  return servos[this->servoIndex]->duration + TRIM_DURATION;
 }
 
 bool Servo::attached()


### PR DESCRIPTION
Hello,

  when I set the servo to 90 degree = 1472us with `writeMicroseconds()` and than I try to get the same value in the another section of my code by `readMicroseconds()`. The values are different. It's because user defined `duration` is changed by `TRIM_DURATION`. This operation must be inverse in `readMicroseconds()`.

Thanks.