### PR TITLE
Fix typos in documentation

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -4,12 +4,12 @@
 
 ### `attach()`
 
-Attach the Servo variable to a pin. Note that in Arduino 0016 and earlier, the Servo library supports servos on only two pins: 9 and 10.
+Attach the Servo variable to a pin. Note that in Arduino IDE 0016 and earlier, the Servo library supports servos on only two pins: 9 and 10.
 
 #### Syntax
 
 ```
-servo.attach(pin) 
+servo.attach(pin)
 servo.attach(pin, min, max)
 ```
 
@@ -23,16 +23,16 @@ servo.attach(pin, min, max)
 #### Example
 
 ```
-#include <Servo.h> 
+#include <Servo.h>
 
 Servo myservo;
 
-void setup() 
-{ 
+void setup()
+{
   myservo.attach(9);
-} 
+}
 
-void loop() {} 
+void loop() {}
 ```
 
 #### See also
@@ -58,17 +58,17 @@ servo.write(angle)
 #### Example
 
 ````
-#include <Servo.h> 
+#include <Servo.h>
 
 Servo myservo;
 
-void setup() 
-{ 
+void setup()
+{
   myservo.attach(9);
   myservo.write(90);  // set servo to mid-point
-} 
+}
 
-void loop() {} 
+void loop() {}
 ````
 #### See also
 
@@ -81,7 +81,7 @@ Writes a value in microseconds (us) to the servo, controlling the shaft accordin
 
 Note that some manufactures do not follow this standard very closely so that servos often respond to values between 700 and 2300. Feel free to increase these endpoints until the servo no longer continues to increase its range. Note however that attempting to drive a servo past its endpoints (often indicated by a growling sound) is a high-current state, and should be avoided.
 
-Continuous-rotation servos will respond to the writeMicrosecond function in an analogous manner to the write function.
+Continuous-rotation servos will respond to the writeMicrosecond function in an manner analogous to the write function.
 
 #### Syntax
 
@@ -97,17 +97,17 @@ servo.writeMicroseconds(us)
 #### Example
 
 ````
-#include <Servo.h> 
+#include <Servo.h>
 
 Servo myservo;
 
-void setup() 
-{ 
+void setup()
+{
   myservo.attach(9);
   myservo.writeMicroseconds(1500);  // set servo to mid-point
-} 
+}
 
-void loop() {} 
+void loop() {}
 ````
 
 #### See also

--- a/docs/readme.md
+++ b/docs/readme.md
@@ -3,7 +3,7 @@
 
 This library allows an Arduino board to control RC (hobby) servo motors. Servos have integrated gears and a shaft that can be precisely controlled. Standard servos allow the shaft to be positioned at various angles, usually between 0 and 180 degrees. Continuous rotation servos allow the rotation of the shaft to be set to various speeds.
 
-The Servo library supports up to 12 motors on most Arduino boards and 48 on the Arduino Mega. On boards other than the Mega, use of the library disables `analogWrite()` (PWM) functionality on pins 9 and 10, whether or not there is a Servo on those pins. On the Mega, up to 12 servos can be used without interfering with PWM functionality; use of 12 to 23 motors will disable PWM on pins 11 and 12. 
+The Servo library supports up to 12 motors on most Arduino boards and 48 on the Arduino Mega. On boards other than the Mega, use of the library disables `analogWrite()` (PWM) functionality on pins 9 and 10, whether or not there is a Servo on those pins. On the Mega, up to 12 servos can be used without interfering with PWM functionality; use of 12 to 23 motors will disable PWM on pins 11 and 12.
 
 To use this library:
 

--- a/examples/Knob/Knob.ino
+++ b/examples/Knob/Knob.ino
@@ -9,13 +9,13 @@
 
 #include <Servo.h>
 
-Servo myservo;  // create servo object to control a servo
+Servo myservo;  // create Servo object to control a servo
 
 int potpin = A0;  // analog pin used to connect the potentiometer
 int val;    // variable to read the value from the analog pin
 
 void setup() {
-  myservo.attach(9);  // attaches the servo on pin 9 to the servo object
+  myservo.attach(9);  // attaches the servo on pin 9 to the Servo object
 }
 
 void loop() {

--- a/examples/Knob/readme.md
+++ b/examples/Knob/readme.md
@@ -1,6 +1,6 @@
 # Knob
 
-Control the position of a RC (hobby) [servo motor](http://en.wikipedia.org/wiki/Servo_motor#RC_servos) with your Arduino and a potentiometer.
+Control the position of an RC (hobby) [servo motor](http://en.wikipedia.org/wiki/Servo_motor#RC_servos) with your Arduino and a potentiometer.
 
 This example makes use of the Arduino `Servo` library.
 
@@ -15,7 +15,7 @@ This example makes use of the Arduino `Servo` library.
 
 Servo motors have three wires: power, ground, and signal. The power wire is typically red, and should be connected to the 5V pin on the Arduino board. The ground wire is typically black or brown and should be connected to a ground pin on the board. The signal pin is typically yellow or orange and should be connected to pin 9 on the board.
 
-The potentiometer should be wired so that its two outer pins are connected to power (+5V) and ground, and its middle pin is connected to analog input 0 on the board.
+The potentiometer should be wired so that its two outer pins are connected to power (5V) and ground, and its middle pin is connected to analog input 0 on the board.
 
 ![](images/knob_BB.png)
 

--- a/examples/Sweep/Sweep.ino
+++ b/examples/Sweep/Sweep.ino
@@ -9,13 +9,13 @@
 
 #include <Servo.h>
 
-Servo myservo;  // create servo object to control a servo
-// twelve servo objects can be created on most boards
+Servo myservo;  // create Servo object to control a servo
+// twelve Servo objects can be created on most boards
 
 int pos = 0;    // variable to store the servo position
 
 void setup() {
-  myservo.attach(9);  // attaches the servo on pin 9 to the servo object
+  myservo.attach(9);  // attaches the servo on pin 9 to the Servo object
 }
 
 void loop() {

--- a/examples/Sweep/readme.md
+++ b/examples/Sweep/readme.md
@@ -1,6 +1,6 @@
 # Sweep
 
-Sweeps the shaft of a RC [servo motor](http://en.wikipedia.org/wiki/Servo_motor#RC_servos) back and forth across 180 degrees.
+Sweeps the shaft of an RC [servo motor](http://en.wikipedia.org/wiki/Servo_motor#RC_servos) back and forth across 180 degrees.
 
 ## Hardware Required
 

--- a/src/Servo.h
+++ b/src/Servo.h
@@ -1,6 +1,6 @@
 /*
-  Servo.h - Interrupt driven Servo library for Arduino using 16 bit timers- Version 2
-  Copyright (c) 2009 Michael Margolis.  All right reserved.
+  Servo.h - Interrupt driven Servo library for Arduino using 16 bit timers - Version 2
+  Copyright (c) 2009 Michael Margolis. All right reserved.
 
   This library is free software; you can redistribute it and/or
   modify it under the terms of the GNU Lesser General Public
@@ -17,15 +17,15 @@
   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-/* 
-  A servo is activated by creating an instance of the Servo class passing 
+/*
+  A servo is activated by creating an instance of the Servo class passing
   the desired pin to the attach() method.
-  The servos are pulsed in the background using the value most recently 
+  The servos are pulsed in the background using the value most recently
   written using the write() method.
 
-  Note that analogWrite of PWM on pins associated with the timer are 
+  Note that analogWrite of PWM on pins associated with the timer are
   disabled when the first servo is attached.
-  Timers are seized as needed in groups of 12 servos - 24 servos use two 
+  Timers are seized as needed in groups of 12 servos - 24 servos use two
   timers, 48 servos will use four.
   The sequence used to seize timers is defined in timers.h
 
@@ -33,16 +33,16 @@
 
     Servo - Class for manipulating servo motors connected to Arduino pins.
 
-    attach(pin )  - Attaches a servo motor to an I/O pin.
+    attach(pin ) - Attaches a servo motor to an I/O pin.
     attach(pin, min, max  ) - Attaches to a pin setting min and max values in microseconds
-    default min is 544, max is 2400  
- 
-    write()     - Sets the servo angle in degrees.  (invalid angle that is valid as pulse in microseconds is treated as microseconds)
-    writeMicroseconds() - Sets the servo pulse width in microseconds 
-    read()      - Gets the last written servo pulse width as an angle between 0 and 180. 
+    default min is 544, max is 2400
+
+    write()     - Sets the servo angle in degrees. (invalid angle that is valid as pulse in microseconds is treated as microseconds)
+    writeMicroseconds() - Sets the servo pulse width in microseconds
+    read()      - Gets the last written servo pulse width as an angle between 0 and 180.
     readMicroseconds()   - Gets the last written servo pulse width in microseconds. (was read_us() in first release)
-    attached()  - Returns true if there is a servo attached. 
-    detach()    - Stops an attached servos from pulsing its I/O pin. 
+    attached()  - Returns true if there is a servo attached.
+    detach()    - Stops an attached servos from pulsing its I/O pin.
  */
 
 #ifndef Servo_h
@@ -50,8 +50,8 @@
 
 #include <inttypes.h>
 
-/* 
- * Defines for 16 bit timers used with Servo library 
+/*
+ * Defines for 16 bit timers used with Servo library
  *
  * If _useTimerX is defined then TimerX is a 16 bit timer on the current board
  * timer16_Sequence_t enumerates the sequence that the timers should be allocated
@@ -81,12 +81,12 @@
 
 #define Servo_VERSION           2     // software version of this library
 
-#define MIN_PULSE_WIDTH       544     // the shortest pulse sent to a servo  
-#define MAX_PULSE_WIDTH      2400     // the longest pulse sent to a servo 
+#define MIN_PULSE_WIDTH       544     // the shortest pulse sent to a servo
+#define MAX_PULSE_WIDTH      2400     // the longest pulse sent to a servo
 #define DEFAULT_PULSE_WIDTH  1500     // default pulse width when servo is attached
-#define REFRESH_INTERVAL    20000     // minimum time to refresh servos in microseconds 
+#define REFRESH_INTERVAL    20000     // minimum time to refresh servos in microseconds
 
-#define SERVOS_PER_TIMER       12     // the maximum number of servos controlled by one timer 
+#define SERVOS_PER_TIMER       12     // the maximum number of servos controlled by one timer
 #define MAX_SERVOS   (_Nbr_16timers  * SERVOS_PER_TIMER)
 
 #define INVALID_SERVO         255     // flag indicating an invalid servo index
@@ -95,8 +95,8 @@
 
 typedef struct  {
   uint8_t nbr        :6 ;             // a pin number from 0 to 63
-  uint8_t isActive   :1 ;             // true if this channel is enabled, pin not pulsed if false 
-} ServoPin_t   ;  
+  uint8_t isActive   :1 ;             // true if this channel is enabled, pin not pulsed if false
+} ServoPin_t   ;
 
 typedef struct {
   ServoPin_t Pin;
@@ -108,17 +108,17 @@ class Servo
 public:
   Servo();
   uint8_t attach(int pin);           // attach the given pin to the next free channel, sets pinMode, returns channel number or INVALID_SERVO if failure
-  uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes. 
+  uint8_t attach(int pin, int min, int max); // as above but also sets min and max values for writes.
   void detach();
-  void write(int value);             // if value is < 200 its treated as an angle, otherwise as pulse width in microseconds 
-  void writeMicroseconds(int value); // Write pulse width in microseconds 
+  void write(int value);             // if value is < 200 it's treated as an angle, otherwise as pulse width in microseconds
+  void writeMicroseconds(int value); // Write pulse width in microseconds
   int read();                        // returns current pulse width as an angle between 0 and 180 degrees
   int readMicroseconds();            // returns current pulse width in microseconds for this servo (was read_us() in first release)
-  bool attached();                   // return true if this servo is attached, otherwise false 
+  bool attached();                   // return true if this servo is attached, otherwise false
 private:
    uint8_t servoIndex;               // index into the channel data for this servo
-   int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH    
-   int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH   
+   int8_t min;                       // minimum is this value times 4 added to MIN_PULSE_WIDTH
+   int8_t max;                       // maximum is this value times 4 added to MAX_PULSE_WIDTH
 };
 
 #endif

--- a/src/avr/Servo.cpp
+++ b/src/avr/Servo.cpp
@@ -1,5 +1,5 @@
 /*
- Servo.cpp - Interrupt driven Servo library for Arduino using 16 bit timers- Version 2
+ Servo.cpp - Interrupt driven Servo library for Arduino using 16 bit timers - Version 2
  Copyright (c) 2009 Michael Margolis.  All right reserved.
 
  This library is free software; you can redistribute it and/or
@@ -24,7 +24,7 @@
 
 #include "Servo.h"
 
-#define usToTicks(_us)    (( clockCyclesPerMicrosecond()* _us) / 8)     // converts microseconds to tick (assumes prescale of 8)  // 12 Aug 2009
+#define usToTicks(_us)    (( clockCyclesPerMicrosecond()* _us) / 8)     // converts microseconds to ticks (assumes prescaler of 8)  // 12 Aug 2009
 #define ticksToUs(_ticks) (( (unsigned)_ticks * 8)/ clockCyclesPerMicrosecond() ) // converts from ticks back to microseconds
 
 
@@ -62,7 +62,7 @@ static inline void handle_interrupts(timer16_Sequence_t timer, volatile uint16_t
   if( SERVO_INDEX(timer,Channel[timer]) < ServoCount && Channel[timer] < SERVOS_PER_TIMER) {
     *OCRnA = *TCNTn + SERVO(timer,Channel[timer]).ticks;
     if(SERVO(timer,Channel[timer]).Pin.isActive == true)     // check if activated
-      digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,HIGH); // its an active channel so pulse it high
+      digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,HIGH); // it's an active channel so pulse it high
   }
   else {
     // finished all channels so wait for the refresh period to expire before starting over

--- a/src/avr/ServoTimers.h
+++ b/src/avr/ServoTimers.h
@@ -1,5 +1,5 @@
 /*
-  Servo.h - Interrupt driven Servo library for Arduino using 16 bit timers- Version 2
+  Servo.h - Interrupt driven Servo library for Arduino using 16 bit timers - Version 2
   Copyright (c) 2009 Michael Margolis.  All right reserved.
 
   This library is free software; you can redistribute it and/or

--- a/src/megaavr/Servo.cpp
+++ b/src/megaavr/Servo.cpp
@@ -3,7 +3,7 @@
 #include <Arduino.h>
 #include <Servo.h>
 
-#define usToTicks(_us)    ((clockCyclesPerMicrosecond() / 16 * _us) / 4)                 // converts microseconds to tick
+#define usToTicks(_us)    ((clockCyclesPerMicrosecond() / 16 * _us) / 4)                 // converts microseconds to ticks
 #define ticksToUs(_ticks) (((unsigned) _ticks * 16) / (clockCyclesPerMicrosecond() / 4))   // converts from ticks back to microseconds
 
 #define TRIM_DURATION  5                                   // compensation ticks to trim adjust for digitalWrite delays

--- a/src/nrf52/Servo.cpp
+++ b/src/nrf52/Servo.cpp
@@ -35,7 +35,7 @@ Servo::Servo()
 {
   if (ServoCount < MAX_SERVOS) {
     this->servoIndex = ServoCount++;                    // assign a servo index to this instance
-  } else {                                                 
+  } else {
     this->servoIndex = INVALID_SERVO;  					// too many servos
   }
 
@@ -43,7 +43,7 @@ Servo::Servo()
 
 uint8_t Servo::attach(int pin)
 {
-	
+
 	return this->attach(pin, 0, 2500);
 }
 
@@ -59,9 +59,9 @@ uint8_t Servo::attach(int pin, int min, int max)
 	if (max > servo_max) max = servo_max;
 	this->min  = min;
     this->max  = max;
-	
+
 	servos[this->servoIndex].Pin.isActive = true;
-	
+
   }
   return this->servoIndex;
 }
@@ -73,13 +73,13 @@ void Servo::detach()
 
 
 void Servo::write(int value)
-{  
+{
 	if (value < 0)
 		value = 0;
 	else if (value > 180)
 		value = 180;
 	value = map(value, 0, 180, MIN_PULSE, MAX_PULSE);
-	
+
 	writeMicroseconds(value);
 }
 
@@ -117,7 +117,7 @@ int Servo::read() // return the value as degrees
 }
 
 int Servo::readMicroseconds()
-{	
+{
 	uint8_t channel, instance;
 	uint8_t pin=servos[this->servoIndex].Pin.nbr;
 	instance=(g_APinDescription[pin].ulPWMChannel & 0xF0)/16;

--- a/src/nrf52/ServoTimers.h
+++ b/src/nrf52/ServoTimers.h
@@ -17,7 +17,7 @@
 */
 
 /*
- * nRF52 doesn't use timer, but PWM. This file include definitions to keep
+ * nRF52 doesn't use timer, but PWM. This file includes definitions to keep
  * compatibility with the Servo library standards.
  */
 

--- a/src/renesas/Servo.cpp
+++ b/src/renesas/Servo.cpp
@@ -35,7 +35,7 @@
 #define SERVO_US_PER_CYCLE          (20000)
 #define SERVO_IO_PORT_ADDR(pn)      &((R_PORT0 + ((uint32_t) (R_PORT1 - R_PORT0) * (pn)))->PCNTR3)
 
-// Internal Servo sturct to keep track of RA configuration.
+// Internal Servo struct to keep track of RA configuration.
 typedef struct {
     // Servo period in microseconds.
     uint32_t period_us;

--- a/src/sam/Servo.cpp
+++ b/src/sam/Servo.cpp
@@ -21,7 +21,7 @@
 #include <Arduino.h>
 #include <Servo.h>
 
-#define usToTicks(_us)    (( clockCyclesPerMicrosecond() * _us) / 32)     // converts microseconds to tick
+#define usToTicks(_us)    (( clockCyclesPerMicrosecond() * _us) / 32)     // converts microseconds to ticks
 #define ticksToUs(_ticks) (( (unsigned)_ticks * 32)/ clockCyclesPerMicrosecond() ) // converts from ticks back to microseconds
 
 #define TRIM_DURATION       2                               // compensation ticks to trim adjust for digitalWrite delays
@@ -89,7 +89,7 @@ void Servo_Handler(timer16_Sequence_t timer, Tc *tc, uint8_t channel)
     if( SERVO_INDEX(timer,Channel[timer]) < ServoCount && Channel[timer] < SERVOS_PER_TIMER) {
         tc->TC_CHANNEL[channel].TC_RA = tc->TC_CHANNEL[channel].TC_CV + SERVO(timer,Channel[timer]).ticks;
         if(SERVO(timer,Channel[timer]).Pin.isActive == true) {    // check if activated
-            digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,HIGH); // its an active channel so pulse it high
+            digitalWrite( SERVO(timer,Channel[timer]).Pin.nbr,HIGH); // it's an active channel so pulse it high
         }
     }
     else {

--- a/src/samd/Servo.cpp
+++ b/src/samd/Servo.cpp
@@ -21,7 +21,7 @@
 #include <Arduino.h>
 #include <Servo.h>
 
-#define usToTicks(_us)    ((clockCyclesPerMicrosecond() * _us) / 16)                 // converts microseconds to tick
+#define usToTicks(_us)    ((clockCyclesPerMicrosecond() * _us) / 16)                 // converts microseconds to ticks
 #define ticksToUs(_ticks) (((unsigned) _ticks * 16) / clockCyclesPerMicrosecond())   // converts from ticks back to microseconds
 
 #define TRIM_DURATION  5                                   // compensation ticks to trim adjust for digitalWrite delays
@@ -133,7 +133,7 @@ static void _initISR(Tc *tc, uint8_t channel, uint32_t id, IRQn_Type irqn, uint8
     // Set timer counter mode as normal PWM
     tc->COUNT16.CTRLA.reg |= TC_CTRLA_WAVEGEN_NPWM;
 
-    // Set the prescaler factor to GCLK_TC/16.  At nominal 48 MHz GCLK_TC this is 3000 ticks per millisecond
+    // Set the prescaler factor to GCLK_TC/16. At nominal 48 MHz GCLK_TC this is 3000 ticks per millisecond
     tc->COUNT16.CTRLA.reg |= TC_CTRLA_PRESCALER_DIV16;
 
     // Count up

--- a/src/stm32f4/Servo.cpp
+++ b/src/stm32f4/Servo.cpp
@@ -33,7 +33,7 @@
 #include "pwm.h"
 #include "math.h"
 
-// 20 millisecond period config.  For a 1-based prescaler,
+// 20 millisecond period config. For a 1-based prescaler,
 //
 //    (prescaler * overflow / CYC_MSEC) msec = 1 timer cycle = 20 msec
 // => prescaler * overflow = 20 * CYC_MSEC

--- a/src/stm32f4/ServoTimers.h
+++ b/src/stm32f4/ServoTimers.h
@@ -49,17 +49,17 @@
  *
  * This implementation only allows Servo instances to attach() to pins
  * that already have a timer channel associated with them, and just
- * uses pwmWrite() to drive the wave.
+ * uses analogWrite() to drive the wave.
  *
  * This introduces an incompatibility: while the Arduino
  * implementation of attach() returns the affected channel on success
  * and 0 on failure, this one returns true on success and false on
  * failure.
  *
- * RC Servos expect a pulse every 20 ms.  Since periods are set for
+ * RC Servos expect a pulse every 20 ms. Since periods are set for
  * entire timers, rather than individual channels, attach()ing a Servo
  * to a pin can interfere with other pins associated with the same
- * timer.  As always, your board's pin map is your friend.
+ * timer. As always, your board's pin map is your friend.
  */
 
 // Pin number of unattached pins
@@ -70,7 +70,7 @@
 
 
 // Default min/max pulse widths (in microseconds) and angles (in
-// degrees).  Values chosen for Arduino compatibility.  These values
+// degrees). Values chosen for Arduino compatibility. These values
 // are part of the public API; DO NOT CHANGE THEM.
 #define MIN_ANGLE               0
 #define MAX_ANGLE             180
@@ -101,21 +101,21 @@ public:
      *            pin must be capable of PWM output.
      *
      * @param minPulseWidth Minimum pulse width to write to pin, in
-     *                      microseconds.  This will be associated
-     *                      with a minAngle degree angle.  Defaults to
+     *                      microseconds. This will be associated
+     *                      with a minAngle degree angle. Defaults to
      *                      SERVO_DEFAULT_MIN_PW = 544.
      *
      * @param maxPulseWidth Maximum pulse width to write to pin, in
-     *                      microseconds.  This will be associated
+     *                      microseconds. This will be associated
      *                      with a maxAngle degree angle. Defaults to
      *                      SERVO_DEFAULT_MAX_PW = 2400.
      *
      * @param minAngle Target angle (in degrees) associated with
-     *                 minPulseWidth.  Defaults to
+     *                 minPulseWidth. Defaults to
      *                 SERVO_DEFAULT_MIN_ANGLE = 0.
      *
      * @param maxAngle Target angle (in degrees) associated with
-     *                 maxPulseWidth.  Defaults to
+     *                 maxPulseWidth. Defaults to
      *                 SERVO_DEFAULT_MAX_ANGLE = 180.
      *
      * @sideeffect May set pinMode(pin, PWM).
@@ -140,7 +140,7 @@ public:
     /**
      * @brief Set the servomotor target angle.
      *
-     * @param angle Target angle, in degrees.  If the target angle is
+     * @param angle Target angle, in degrees. If the target angle is
      *              outside the range specified at attach() time, it
      *              will be clamped to lie in that range.
      *
@@ -161,7 +161,7 @@ public:
     void writeMicroseconds(uint16 pulseWidth);
 
     /**
-     * Get the servomotor's target angle, in degrees.  This will
+     * Get the servomotor's target angle, in degrees. This will
      * lie inside the range specified at attach() time.
      *
      * @see Servo::attach()
@@ -169,7 +169,7 @@ public:
     int read() const;
 
     /**
-     * Get the current pulse width, in microseconds.  This will
+     * Get the current pulse width, in microseconds. This will
      * lie within the range specified at attach() time.
      *
      * @see Servo::attach()


### PR DESCRIPTION
A misspelled word was introduced to the project content by a developer circumventing the CI system through a push directly to the `master` branch (https://github.com/arduino-libraries/Servo/commit/5d580e24eb563ba5c8343ebb3c2e156853391060). This caused the failure of all runs of the "Spell Check" GitHub Actions workflow from that point onward:

https://github.com/arduino-libraries/Servo/actions/runs/6940870827/job/18880592376#step:4:17

```text
Error: ./src/renesas/Servo.cpp:38: sturct ==> struct
```

While I was fixing that, I did a comprehensive review of all files in the repository and fixed all the other typos I found.