### PR TITLE
Fix info about PWM pins in Mega

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -3,7 +3,7 @@
 
 This library allows an Arduino board to control RC (hobby) servo motors. Servos have integrated gears and a shaft that can be precisely controlled. Standard servos allow the shaft to be positioned at various angles, usually between 0 and 180 degrees. Continuous rotation servos allow the rotation of the shaft to be set to various speeds.
 
-The Servo library supports up to 12 motors on most Arduino boards and 48 on the Arduino Mega. On boards other than the Mega, use of the library disables `analogWrite()` (PWM) functionality on pins 9 and 10, whether or not there is a Servo on those pins. On the Mega, up to 12 servos can be used without interfering with PWM functionality; use of 12 to 23 motors will disable PWM on pins 11 and 12.
+The Servo library supports up to 12 motors on most Arduino boards and 48 on the Arduino Mega. On boards other than the Mega, use of the library disables `analogWrite()` (PWM) functionality on pins 9 and 10, whether or not there is a Servo on those pins. On the Mega, using up to 12 motors will disable PWM on pins 44, 45 and 46; use of 12 to 23 motors will disable PWM on pins 11 and 12.
 
 To use this library:
 


### PR DESCRIPTION
Fixes incorrect information in documentation (#64), I found more about it here: [https://arduino.stackexchange.com/questions/13415/arduino-mega-pwm-pins-stop-working-for-leds-once-servo-is-attached](https://arduino.stackexchange.com/questions/13415/arduino-mega-pwm-pins-stop-working-for-leds-once-servo-is-attached).