### PR TITLE
Fix map from microseconds to angle in renesas Servo::read

### DIFF
--- a/src/renesas/Servo.cpp
+++ b/src/renesas/Servo.cpp
@@ -245,7 +245,7 @@ int Servo::read()
 {
     if (servoIndex != SERVO_INVALID_INDEX) {
         ra_servo_t *servo = &ra_servos[servoIndex];
-        return map(servo->period_us, servo->period_min, servo->period_max, 0, 180);
+        return map(servo->period_us + 1, servo->period_min, servo->period_max, 0, 180);
     }
     return 0;
 }


### PR DESCRIPTION
For the renesas implementation, `Servo::read()` reports a different value to what was previously set with `Servo::write()`.

The value reported by `read()` is 1 less than the value written using `write()`.

In the `Servo::read` function for renesas, the mapping from microseconds to angle is inconsistent with other implementations, such as avr, which add +1 to the microseconds value before mapping.

Tested on a Uno Rev 4 Wifi => value returned by read was equal to value written for all angles from 0 to 180.