### PR TITLE
Fix mbed not using REFRESH_INTERVAL

### DIFF
--- a/src/mbed/Servo.cpp
+++ b/src/mbed/Servo.cpp
@@ -1,5 +1,6 @@
 #if defined(ARDUINO_ARCH_MBED)
 
+#include <chrono>
 #include <Arduino.h>
 #include <Servo.h>
 #include <mbed.h>
@@ -28,11 +29,11 @@ public:
 
     void start(uint32_t duration_us) {
       duration = duration_us;
-      ticker.attach(mbed::callback(this, &ServoImpl::call), 0.02f);
+      ticker.attach(mbed::callback(this, &ServoImpl::call), std::chrono::microseconds(REFRESH_INTERVAL));
     }
 
     void call() {
-        timeout.attach(mbed::callback(this, &ServoImpl::toggle), duration / 1e6);
+        timeout.attach(mbed::callback(this, &ServoImpl::toggle), std::chrono::microseconds(duration));
         toggle();
     }
 


### PR DESCRIPTION
This pull request refactors the Servo library for mbed-based boards to utilize std::chrono durations instead of manual conversions with floating-point numbers. The 20ms interval was hardcoded for mbed platform only.

Changes:

- Fix bug on mbed platform of not using REFRESH_INTERVAL interval at all
- Modified ServoImpl::start() and ServoImpl::call() to use std::chrono::microseconds.
- Eliminated floating-point divisions by 1e6f and 1e6.
- Ensured backward compatibility by keeping existing functionality intact.

### Benefits:

- Enhanced type safety and precision.
- Simplified codebase.
- Facilitates dynamic adjustment of REFRESH_INTERVAL.

### Testing:

- Verified functionality with default REFRESH_INTERVAL of 20000 microseconds.
- Tested with REFRESH_INTERVAL set to 10000 and 5000 microseconds.
- Confirmed correct servo operation and signal timing using an oscilloscope.

### Notes:

This change aligns the Servo library with the updated mbed OS API that favours `std::chrono` durations since mbedOS 6.0.0, see 

https://github.com/arduino/ArduinoCore-mbed/blob/702daa02e244fb8710b48599f38786a67c590699/cores/arduino/mbed/drivers/include/drivers/Ticker.h#L85-L122