### PR TITLE
Support angle and microseconds for nrf52, renesasm stm32f4

### DIFF
--- a/src/nrf52/Servo.cpp
+++ b/src/nrf52/Servo.cpp
@@ -81,7 +81,7 @@ void Servo::write(int value)
 			value = 180;
 		value = map(value, 0, 180, MIN_PULSE, MAX_PULSE);
 	}
-	writeMicroseconds(value);
+	this->writeMicroseconds(value);
 }
 
 

--- a/src/nrf52/Servo.cpp
+++ b/src/nrf52/Servo.cpp
@@ -74,12 +74,13 @@ void Servo::detach()
 
 void Servo::write(int value)
 {
-	if (value < 0)
-		value = 0;
-	else if (value > 180)
-		value = 180;
-	value = map(value, 0, 180, MIN_PULSE, MAX_PULSE);
-
+	if(value < MIN_PULSE_WIDTH) {
+		if (value < 0)
+			value = 0;
+		else if (value > 180)
+			value = 180;
+		value = map(value, 0, 180, MIN_PULSE, MAX_PULSE);
+	}
 	writeMicroseconds(value);
 }
 

--- a/src/renesas/Servo.cpp
+++ b/src/renesas/Servo.cpp
@@ -232,12 +232,15 @@ void Servo::detach()
     }
 }
 
-void Servo::write(int angle)
+void Servo::write(int value)
 {
     if (servoIndex != SERVO_INVALID_INDEX) {
         ra_servo_t *servo = &ra_servos[servoIndex];
-        angle = constrain(angle, 0, 180);
-        writeMicroseconds(map(angle, 0, 180, servo->period_min, servo->period_max));
+        if(value < MIN_PULSE_WIDTH) {
+            value = constrain(value, 0, 180);
+            value = map(value, 0, 180, servo->period_min, servo->period_max);
+        }
+        this->writeMicroseconds(value);
     }
 }
 

--- a/src/renesas/Servo.cpp
+++ b/src/renesas/Servo.cpp
@@ -240,7 +240,7 @@ void Servo::write(int value)
             value = constrain(value, 0, 180);
             value = map(value, 0, 180, servo->period_min, servo->period_max);
         }
-        this->writeMicroseconds(value);
+        writeMicroseconds(value);
     }
 }
 

--- a/src/stm32f4/Servo.cpp
+++ b/src/stm32f4/Servo.cpp
@@ -148,9 +148,12 @@ bool Servo::detach() {
     return true;
 }
 
-void Servo::write(int degrees) {
-    degrees = constrain(degrees, this->minAngle, this->maxAngle);
-    this->writeMicroseconds(ANGLE_TO_US(degrees));
+void Servo::write(int value) {
+    if(value < MIN_PULSE_WIDTH) {
+        value = constrain(value, this->minAngle, this->maxAngle);
+        value = ANGLE_TO_US(value);
+    }
+    this->writeMicroseconds(value);
 }
 
 int Servo::read() const {


### PR DESCRIPTION
Address issue #133

I tested this with an Arduino UNO R4 Wifi.  With the code change I get the same scope output for both of these:

```
  myservo.writeMicroseconds(1500);              // tell servo to go to position in variable 'pos'
  delay(1000);                       // waits 15ms for the servo to reach the position
  myservo.write(1500);              // tell servo to go to position in variable 'pos'
  delay(1000);       
```

I don't have an nrf52 or stm32f4 board.  I compiled the nrf52 target and there were no errors.  I installed the board manager for stm32 but it seems to ship with its own Servo library.
