### PR TITLE
Doc: clarify that Servo::read() does not read the servo angle

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -118,7 +118,9 @@ void loop() {}
 
 ### `read()`
 
-Read the current angle of the servo (the value passed to the last call to [write()](#write)).
+Read the current setpoint of the servo (the angle passed to the last call to [write()](#write)).
+
+Note that the servo has no way of reporting its current physical orientation. This method returns the angle that has been requested to the servo, whether this angle has already been reached or not.
 
 #### Syntax
 
@@ -132,7 +134,7 @@ servo.read()
 
 #### Returns
 
-The angle of the servo, from 0 to 180 degrees.
+The setpoint of the servo, as an angle from 0 to 180 degrees.
 
 #### See also
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -120,7 +120,7 @@ void loop() {}
 
 Read the current setpoint of the servo (the angle passed to the last call to [write()](#write)).
 
-Note that the servo has no way of reporting its current physical orientation. This method returns the angle that has been requested to the servo, whether this angle has already been reached or not.
+Note that the servo has no way of reporting its current physical orientation. This method returns the angle to which the sketch program has requested the servo to move, regardless of whether the servo has already reached that angle.
 
 #### Syntax
 


### PR DESCRIPTION
The documentation of `Servo::read()` states:

> Read the current angle of the servo [...]

This is misleading: the servo has no way of reporting its current angle. Although the sentence in parentheses attempts to clarify that this is “_the value passed to the last call to write()_”, this clarification is not prominent enough. I have witnessed students use `Servo::read()` as a way to check that the requested position has been reached.

This pull request makes absolutely clear that `Servo::read()` reads the servo _setpoint_, and that there is no way to read its current angular position.