### PR TITLE
esp32: add support for ESP-IDF v5.5

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -6,4 +6,4 @@ sentence=Allows Arduino boards to control a variety of servo motors.
 paragraph=This library can control a great number of servos.<br />It makes careful use of timers: the library can control 12 servos using only 1 timer.<br />On the Arduino Due you can control up to 60 servos.
 category=Device Control
 url=https://www.arduino.cc/reference/en/libraries/servo/
-architectures=avr,megaavr,sam,samd,nrf52,stm32f4,mbed,mbed_nano,mbed_portenta,mbed_rp2040,renesas,renesas_portenta,renesas_uno
+architectures=avr,megaavr,sam,samd,nrf52,stm32f4,mbed,mbed_nano,mbed_portenta,mbed_rp2040,renesas,renesas_portenta,renesas_uno,esp32

--- a/src/esp32/ServoTimers.h
+++ b/src/esp32/ServoTimers.h
@@ -1,6 +1,10 @@
 #define MAX_PWM_SERVOS             16
 
+#if ESP_IDF_VERSION_MAJOR < 5
 #define LEDC_MAX_BIT_WIDTH      SOC_LEDC_TIMER_BIT_WIDE_NUM
+#else
+#define LEDC_MAX_BIT_WIDTH      SOC_LEDC_TIMER_BIT_WIDTH
+#endif
 
 constexpr uint32_t BIT_RESOLUTION = (1 << LEDC_MAX_BIT_WIDTH) - 1;
 


### PR DESCRIPTION
This PR improves the newly merged ESP32 support from #139 by adding compatibility for the newer ESP-IDF v5.x.  The version now in `master` uses the older variants of the LEDC APIs, which received incompatible changes as described in the [Arduino ESP32 project's 2.x-to-3.0 migration guide](https://github.com/espressif/arduino-esp32/tree/master/docs/en/migration_guides/2.x_to_3.0.rst).

These changes aim to provide compatibility with both versions of `arduino-esp32`, though I have only tested them with the newer version.