### PR TITLE
[SAM] Refactor timer definitions for conditional compilation

### DIFF
--- a/src/sam/Servo.cpp
+++ b/src/sam/Servo.cpp
@@ -47,27 +47,27 @@ static volatile int8_t Channel[_Nbr_16timers ];             // counter for the s
 /// Interrupt handler for the TC0 channel 1.
 //------------------------------------------------------------------------------
 void Servo_Handler(timer16_Sequence_t timer, Tc *pTc, uint8_t channel);
-#if defined (_useTimer1)
+#if defined(_useTimer1) && (_useTimer1)
 void HANDLER_FOR_TIMER1(void) {
     Servo_Handler(_timer1, TC_FOR_TIMER1, CHANNEL_FOR_TIMER1);
 }
 #endif
-#if defined (_useTimer2)
+#if defined(_useTimer2) && (_useTimer2)
 void HANDLER_FOR_TIMER2(void) {
     Servo_Handler(_timer2, TC_FOR_TIMER2, CHANNEL_FOR_TIMER2);
 }
 #endif
-#if defined (_useTimer3)
+#if defined(_useTimer3) && (_useTimer3)
 void HANDLER_FOR_TIMER3(void) {
     Servo_Handler(_timer3, TC_FOR_TIMER3, CHANNEL_FOR_TIMER3);
 }
 #endif
-#if defined (_useTimer4)
+#if defined(_useTimer4) && (_useTimer4)
 void HANDLER_FOR_TIMER4(void) {
     Servo_Handler(_timer4, TC_FOR_TIMER4, CHANNEL_FOR_TIMER4);
 }
 #endif
-#if defined (_useTimer5)
+#if defined(_useTimer5) && (_useTimer5)
 void HANDLER_FOR_TIMER5(void) {
     Servo_Handler(_timer5, TC_FOR_TIMER5, CHANNEL_FOR_TIMER5);
 }
@@ -126,23 +126,23 @@ static void _initISR(Tc *tc, uint32_t channel, uint32_t id, IRQn_Type irqn)
 
 static void initISR(timer16_Sequence_t timer)
 {
-#if defined (_useTimer1)
+#if defined(_useTimer1) && (_useTimer1)
     if (timer == _timer1)
         _initISR(TC_FOR_TIMER1, CHANNEL_FOR_TIMER1, ID_TC_FOR_TIMER1, IRQn_FOR_TIMER1);
 #endif
-#if defined (_useTimer2)
+#if defined(_useTimer2) && (_useTimer2)
     if (timer == _timer2)
         _initISR(TC_FOR_TIMER2, CHANNEL_FOR_TIMER2, ID_TC_FOR_TIMER2, IRQn_FOR_TIMER2);
 #endif
-#if defined (_useTimer3)
+#if defined(_useTimer3) && (_useTimer3)
     if (timer == _timer3)
         _initISR(TC_FOR_TIMER3, CHANNEL_FOR_TIMER3, ID_TC_FOR_TIMER3, IRQn_FOR_TIMER3);
 #endif
-#if defined (_useTimer4)
+#if defined(_useTimer4) && (_useTimer4)
     if (timer == _timer4)
         _initISR(TC_FOR_TIMER4, CHANNEL_FOR_TIMER4, ID_TC_FOR_TIMER4, IRQn_FOR_TIMER4);
 #endif
-#if defined (_useTimer5)
+#if defined(_useTimer5) && (_useTimer5)
     if (timer == _timer5)
         _initISR(TC_FOR_TIMER5, CHANNEL_FOR_TIMER5, ID_TC_FOR_TIMER5, IRQn_FOR_TIMER5);
 #endif
@@ -150,19 +150,19 @@ static void initISR(timer16_Sequence_t timer)
 
 static void finISR(timer16_Sequence_t timer)
 {
-#if defined (_useTimer1)
+#if defined(_useTimer1) && (_useTimer1)
     TC_Stop(TC_FOR_TIMER1, CHANNEL_FOR_TIMER1);
 #endif
-#if defined (_useTimer2)
+#if defined(_useTimer2) && (_useTimer2)
     TC_Stop(TC_FOR_TIMER2, CHANNEL_FOR_TIMER2);
 #endif
-#if defined (_useTimer3)
+#if defined(_useTimer3) && (_useTimer3)
     TC_Stop(TC_FOR_TIMER3, CHANNEL_FOR_TIMER3);
 #endif
-#if defined (_useTimer4)
+#if defined(_useTimer4) && (_useTimer4)
     TC_Stop(TC_FOR_TIMER4, CHANNEL_FOR_TIMER4);
 #endif
-#if defined (_useTimer5)
+#if defined(_useTimer5) && (_useTimer5)
     TC_Stop(TC_FOR_TIMER5, CHANNEL_FOR_TIMER5);
 #endif
 }

--- a/src/sam/ServoTimers.h
+++ b/src/sam/ServoTimers.h
@@ -30,11 +30,21 @@
  */
 
 // For SAM3X:
-#define _useTimer1
-#define _useTimer2
-#define _useTimer3
-#define _useTimer4
-#define _useTimer5
+#ifndef _useTimer1
+#define _useTimer1 1
+#endif
+#ifndef _useTimer2
+#define _useTimer2 1
+#endif
+#ifndef _useTimer3
+#define _useTimer3 1
+#endif
+#ifndef _useTimer4
+#define _useTimer4 1
+#endif
+#ifndef _useTimer5
+#define _useTimer5 1
+#endif
 
 /*
   TC0, chan 0 => TC0_Handler
@@ -48,35 +58,35 @@
   TC2, chan 2 => TC8_Handler
  */
 
-#if defined (_useTimer1)
+#if defined(_useTimer1) && (_useTimer1)
 #define TC_FOR_TIMER1       TC1
 #define CHANNEL_FOR_TIMER1  0
 #define ID_TC_FOR_TIMER1    ID_TC3
 #define IRQn_FOR_TIMER1     TC3_IRQn
 #define HANDLER_FOR_TIMER1  TC3_Handler
 #endif
-#if defined (_useTimer2)
+#if defined(_useTimer2) && (_useTimer2)
 #define TC_FOR_TIMER2       TC1
 #define CHANNEL_FOR_TIMER2  1
 #define ID_TC_FOR_TIMER2    ID_TC4
 #define IRQn_FOR_TIMER2     TC4_IRQn
 #define HANDLER_FOR_TIMER2  TC4_Handler
 #endif
-#if defined (_useTimer3)
+#if defined(_useTimer3) && (_useTimer3)
 #define TC_FOR_TIMER3       TC1
 #define CHANNEL_FOR_TIMER3  2
 #define ID_TC_FOR_TIMER3    ID_TC5
 #define IRQn_FOR_TIMER3     TC5_IRQn
 #define HANDLER_FOR_TIMER3  TC5_Handler
 #endif
-#if defined (_useTimer4)
+#if defined(_useTimer4) && (_useTimer4)
 #define TC_FOR_TIMER4       TC0
 #define CHANNEL_FOR_TIMER4  2
 #define ID_TC_FOR_TIMER4    ID_TC2
 #define IRQn_FOR_TIMER4     TC2_IRQn
 #define HANDLER_FOR_TIMER4  TC2_Handler
 #endif
-#if defined (_useTimer5)
+#if defined(_useTimer5) && (_useTimer5)
 #define TC_FOR_TIMER5       TC0
 #define CHANNEL_FOR_TIMER5  0
 #define ID_TC_FOR_TIMER5    ID_TC0
@@ -84,4 +94,20 @@
 #define HANDLER_FOR_TIMER5  TC0_Handler
 #endif
 
-typedef enum { _timer1, _timer2, _timer3, _timer4, _timer5, _Nbr_16timers } timer16_Sequence_t ;
+typedef enum {
+#if defined(_useTimer1) && (_useTimer1)
+_timer1,
+#endif
+#if defined(_useTimer2) && (_useTimer2)
+_timer2,
+#endif
+#if defined(_useTimer3) && (_useTimer3)
+_timer3,
+#endif
+#if defined(_useTimer4) && (_useTimer4)
+_timer4,
+#endif
+#if defined(_useTimer5) && (_useTimer5)
+_timer5,
+#endif
+_Nbr_16timers } timer16_Sequence_t ;


### PR DESCRIPTION
Enhance flexibility in timer definitions by implementing conditional compilation, allowing for better management of timer usage. This change addresses potential multiple definitions by ensuring that only the necessary timers are defined based on the configuration.